### PR TITLE
fixed tracker restart history issues

### DIFF
--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -256,13 +256,14 @@ class MessageProcessor(object):
         Reminders with the same `id` property will overwrite one another
         (i.e. only one of them will eventually run)."""
 
-        for e in events:
-            if isinstance(e, ReminderScheduled):
-                scheduler.add_job(self.handle_reminder, "date",
-                                  run_date=e.trigger_date_time,
-                                  args=[e, dispatcher],
-                                  id=e.name,
-                                  replace_existing=True)
+        if events is not None:
+            for e in events:
+                if isinstance(e, ReminderScheduled):
+                    scheduler.add_job(self.handle_reminder, "date",
+                                      run_date=e.trigger_date_time,
+                                      args=[e, dispatcher],
+                                      id=e.name,
+                                      replace_existing=True)
 
     def _run_action(self, action, tracker, dispatcher):
         # events and return values are used to update

--- a/rasa_core/tracker_store.py
+++ b/rasa_core/tracker_store.py
@@ -57,7 +57,7 @@ class TrackerStore(object):
     def deserialise_tracker(self, sender_id, _json):
         dialogue = pickler.loads(_json)
         tracker = self._init_tracker(sender_id)
-        tracker.update_from_dialogue(dialogue)
+        tracker.recreate_from_dialogue(dialogue)
         return tracker
 
 

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -233,7 +233,6 @@ class DialogueStateTracker(object):
         self._paused = False
         self.latest_action_name = []
         self.latest_message = UserUttered.empty()
-        self._past_user_utterances = []
         self.follow_up_action = None
         self._topic_stack = utils.TopicStack(self.topics, [],
                                              self.default_topic)

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -141,13 +141,6 @@ class DialogueStateTracker(object):
 
         yield tracker  # yields the final state
 
-    def update_from_events(self, events):
-        # type: (List[Event]) -> None
-        """Update the tracker based on a list of events."""
-
-        for e in events:
-            self.update(e)
-
     def _applied_events(self):
         # type: () -> List[Event]
         """Returns all actions that should be applied - w/o reverted events."""
@@ -178,7 +171,7 @@ class DialogueStateTracker(object):
         for event in applied_events:
             event.apply_to(self)
 
-    def update_from_dialogue(self, dialogue):
+    def recreate_from_dialogue(self, dialogue):
         # type: (Dialogue) -> None
         """Use a serialised `Dialogue` to update the trackers state.
 
@@ -190,7 +183,9 @@ class DialogueStateTracker(object):
             raise ValueError("story {0} is not of type Dialogue. "
                              "Have you deserialized it?".format(dialogue))
 
-        self.update_from_events(dialogue.events)
+        self._reset()
+        self.events.extend(dialogue.events)
+        self.replay_events()
 
     def as_dialogue(self):
         # type: () -> Dialogue

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -61,7 +61,7 @@ class PolicyTestCollection(object):
         for story in stories:
             tracker = DialogueStateTracker("default", default_domain.slots)
             dialogue = story.as_dialogue("default", default_domain)
-            tracker.update_from_dialogue(dialogue)
+            tracker.recreate_from_dialogue(dialogue)
             predicted_probabilities = loaded.predict_action_probabilities(
                     tracker, default_domain)
             actual_probabilities = trained_policy.predict_action_probabilities(

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -157,8 +157,8 @@ def test_restart_event(default_domain):
     dialogue = tracker.as_dialogue()
 
     recovered = DialogueStateTracker("default", default_domain.slots,
-                                   default_domain.topics,
-                                   default_domain.default_topic)
+                                     default_domain.topics,
+                                     default_domain.default_topic)
     recovered.recreate_from_dialogue(dialogue)
 
     assert recovered.current_state() == tracker.current_state()

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -42,7 +42,7 @@ def test_tracker_duplicate():
     domain.topics.extend(dialogue_topics)
     tracker = DialogueStateTracker(dialogue.name, domain.slots,
                                    domain.topics, domain.default_topic)
-    tracker.update_from_dialogue(dialogue)
+    tracker.recreate_from_dialogue(dialogue)
     num_actions = len([event
                        for event in dialogue.events
                        if isinstance(event, ActionExecuted)])

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -8,11 +8,12 @@ import glob
 import pytest
 
 from examples.hello_world.run import SimplePolicy
-from rasa_core.actions.action import ActionListen
+from rasa_core.actions.action import ActionListen, ACTION_LISTEN_NAME
 from rasa_core.agent import Agent
 from rasa_core.conversation import Topic
 from rasa_core.domain import TemplateDomain
-from rasa_core.events import UserUttered, TopicSet, ActionExecuted, SlotSet
+from rasa_core.events import UserUttered, TopicSet, ActionExecuted, SlotSet, \
+    Restarted
 from rasa_core.featurizers import BinaryFeaturizer
 from rasa_core.interpreter import NaturalLanguageInterpreter
 from rasa_core.tracker_store import InMemoryTrackerStore, RedisTrackerStore
@@ -57,7 +58,7 @@ def test_tracker_duplicate():
                          ids=stores_to_be_tested_ids())
 def test_tracker_store_storage_and_retrieval(store):
     tracker = store.get_or_create_tracker("some-id")
-    # the retreived tracker should be empty
+    # the retrieved tracker should be empty
     assert tracker.sender_id == "some-id"
 
     # Action listen should be in there
@@ -128,3 +129,39 @@ def test_tracker_state_regression(default_domain):
                 "_greet;utter_greet;action_listen;"
                 "_greet;utter_greet;action_listen")
     assert ";".join([e.as_story_string() for e in tracker.events]) == expected
+
+
+def test_restart_event(default_domain):
+    tracker = DialogueStateTracker("default", default_domain.slots,
+                                   default_domain.topics,
+                                   default_domain.default_topic)
+    # the retrieved tracker should be empty
+    assert len(tracker.events) == 0
+
+    intent = {"name": "greet", "confidence": 1.0}
+    tracker.update(ActionExecuted(ACTION_LISTEN_NAME))
+    tracker.update(UserUttered("_greet", intent, []))
+    tracker.update(ActionExecuted("my_action"))
+    tracker.update(ActionExecuted(ACTION_LISTEN_NAME))
+
+    assert len(tracker.events) == 4
+    assert tracker.latest_message.text == "_greet"
+    assert len(list(tracker.generate_all_prior_states())) == 4
+
+    tracker.update(Restarted())
+
+    assert len(tracker.events) == 6
+    assert tracker.latest_message.text is None
+    assert len(list(tracker.generate_all_prior_states())) == 2
+
+    dialogue = tracker.as_dialogue()
+
+    recovered = DialogueStateTracker("default", default_domain.slots,
+                                   default_domain.topics,
+                                   default_domain.default_topic)
+    recovered.recreate_from_dialogue(dialogue)
+
+    assert recovered.current_state() == tracker.current_state()
+    assert len(recovered.events) == 6
+    assert recovered.latest_message.text is None
+    assert len(list(recovered.generate_all_prior_states())) == 2

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -25,7 +25,7 @@ def tracker_from_dialogue_file(filename, domain=None):
     domain.topics.extend(dialogue_topics)
     tracker = DialogueStateTracker(dialogue.name, domain.slots,
                                    domain.topics, domain.default_topic)
-    tracker.update_from_dialogue(dialogue)
+    tracker.recreate_from_dialogue(dialogue)
     return tracker
 
 


### PR DESCRIPTION
**Proposed changes**:
- previously for every loading of a persisted dialogue more `action_listen` events got appended after a restart leading to a messed up feature history - fixed that

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
