### PR TITLE
Enable loading of inherited Agent classes

### DIFF
--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -50,7 +50,7 @@ class Agent(object):
         ensemble = PolicyEnsemble.load(path, featurizer)
         _interpreter = NaturalLanguageInterpreter.create(interpreter)
         _tracker_store = cls._create_tracker_store(tracker_store, domain)
-        return Agent(domain, ensemble, featurizer, _interpreter, _tracker_store)
+        return cls(domain, ensemble, featurizer, _interpreter, _tracker_store)
 
     def handle_message(
             self,


### PR DESCRIPTION
Currently the Agent class can only load instances of itself and not from inherited classes. The `load` function should return `cls(..)` and not `Agent(..)` to enable this.

**Proposed changes**:
- Change return of `Agent.load` from `Agent(..)` to `cls(..)`

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog