### PR TITLE
Allow to use the train script to start the simple online learning mode on cmd

### DIFF
--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -16,7 +16,8 @@ from rasa_core.interpreter import NaturalLanguageInterpreter
 from rasa_core.policies import PolicyTrainer
 from rasa_core.policies.ensemble import SimplePolicyEnsemble, PolicyEnsemble
 from rasa_core.policies.memoization import MemoizationPolicy
-from rasa_core.policies.online_policy_trainer import OnlinePolicyTrainer
+from rasa_core.policies.online_policy_trainer import OnlinePolicyTrainer, \
+    TrainingFinishedException
 from rasa_core.processor import MessageProcessor
 from rasa_core.tracker_store import InMemoryTrackerStore, TrackerStore
 
@@ -134,19 +135,24 @@ class Agent(object):
             if type(p) == MemoizationPolicy:
                 p.toggle(activate)
 
-    def train(self, filename=None, **kwargs):
-        # type: (Optional[Text], **Any) -> None
+    def train(self, filename=None, model_path=None, **kwargs):
+        # type: (Optional[Text], Optional[Text], **Any) -> None
         """Train the policies / policy ensemble using dialogue data from file"""
 
         trainer = PolicyTrainer(self.policy_ensemble, self.domain,
                                 self.featurizer)
         trainer.train(filename, **kwargs)
 
+        if model_path:
+            self.persist(model_path)
+
     def train_online(self,
-                     filename=None,
-                     input_channel=None,
-                     **kwargs):
-        # type: (Optional[Text], Optional[InputChannel], **Any) -> None
+                     filename=None,  # type: Optional[Text]
+                     input_channel=None,  # type: Optional[InputChannel]
+                     model_path=None,  # type: Optional[Text]
+                     **kwargs  # type: **Any
+                     ):
+        # type: (...) -> None
         """Runs an online training session on the set policies / ensemble.
 
         The policies will be pretrained using the data from `filename`.
@@ -161,6 +167,9 @@ class Agent(object):
         trainer = OnlinePolicyTrainer(self.policy_ensemble, self.domain,
                                       self.featurizer)
         trainer.train(filename, self.interpreter, input_channel, **kwargs)
+
+        if model_path:
+            self.persist(model_path)
 
     def persist(self, model_path):
         # type: (Text) -> None

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -404,6 +404,9 @@ class StoryExported(Event):
 
     type_name = "export"
 
+    def __init__(self, path=None):
+        self.path = path if path else "stories.md"
+
     def __hash__(self):
         return hash(32143124319)
 
@@ -419,7 +422,7 @@ class StoryExported(Event):
     def apply_to(self, tracker):
         # type: (DialogueStateTracker) -> None
 
-        tracker.export_stories_to_file()
+        tracker.export_stories_to_file(self.path)
 
 
 # noinspection PyProtectedMember

--- a/rasa_core/policies/online_policy_trainer.py
+++ b/rasa_core/policies/online_policy_trainer.py
@@ -4,12 +4,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import copy
-import logging
+import logging, os
 
 import numpy as np
-from builtins import range
+from builtins import input, range
 
 from rasa_core import utils
+from rasa_core.actions.action import ACTION_LISTEN_NAME
 from rasa_core.channels.console import ConsoleInputChannel
 from rasa_core.domain import check_domain_sanity
 from rasa_core.events import UserUtteranceReverted, UserUttered, StoryExported
@@ -18,6 +19,11 @@ from rasa_core.policies import PolicyTrainer
 from rasa_core.policies.ensemble import PolicyEnsemble
 
 logger = logging.getLogger(__name__)
+
+
+class TrainingFinishedException(Exception):
+    """Signal a finished online learning. Needed to break out of loops."""
+    pass
 
 
 class OnlinePolicyTrainer(PolicyTrainer):
@@ -51,8 +57,11 @@ class OnlinePolicyTrainer(PolicyTrainer):
                     interpreter=interpreter)
         bot.toggle_memoization(False)
 
-        bot.handle_channel(
-                input_channel if input_channel else ConsoleInputChannel())
+        try:
+            bot.handle_channel(
+                    input_channel if input_channel else ConsoleInputChannel())
+        except TrainingFinishedException:
+            pass    # training has finished
 
 
 class OnlinePolicyEnsemble(PolicyEnsemble):
@@ -106,6 +115,8 @@ class OnlinePolicyEnsemble(PolicyEnsemble):
         X = np.expand_dims(np.array(feature_vector), 0)
         if user_input == "1":
             # max prob prediction was correct
+            if action_name == ACTION_LISTEN_NAME:
+                print("Next user input:")
             return probabilities
         elif user_input == "2":
             # max prob prediction was false, new action required
@@ -123,12 +134,20 @@ class OnlinePolicyEnsemble(PolicyEnsemble):
             tracker.update(latest_message)
             return self.probabilities_using_best_policy(tracker, domain)
         elif user_input == "0":
-            # export current stories and quit
-            tracker.update(StoryExported())
-            exit()
+            self._export_stories(tracker)
+            raise TrainingFinishedException()
         else:
             raise Exception(
                     "Incorrect user input received '{}'".format(user_input))
+
+    def _export_stories(self, tracker):
+        # export current stories and quit
+        export_file_path = input("File to export to (if file exists, this "
+                                 "will append the stories) [stories.md]: ")
+        exported = StoryExported(export_file_path)
+        tracker.update(exported)
+        logger.info("Stories got exported to '{}'.".format(
+                os.path.abspath(exported.path)))
 
     def _fit_example(self, X, y, domain):
         # takes the new example labelled and learns it

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -5,9 +5,12 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+
 from builtins import str
 
 from rasa_core.agent import Agent
+from rasa_core.channels.console import ConsoleInputChannel
+from rasa_core.interpreter import RasaNLUInterpreter, RegexInterpreter
 from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.memoization import MemoizationPolicy
 
@@ -54,8 +57,7 @@ def create_argument_parser():
     parser.add_argument(
             '--online',
             default=False,
-            action='store_const',
-            const=True,
+            action='store_true',
             help="enable online training")
     parser.add_argument(
             '--augmentation',
@@ -66,16 +68,13 @@ def create_argument_parser():
 
 
 def train_dialogue_model(domain_file, stories_file, output_path,
-                         online, nlu_model_path, kwargs):
+                         use_online_learning, nlu_model_path, kwargs):
     agent = Agent(domain_file, policies=[MemoizationPolicy(), KerasPolicy()])
 
-    if online:
-        from rasa_core.channels.console import ConsoleInputChannel
-        from rasa_core.interpreter import RasaNLUInterpreter
+    if use_online_learning:
         if nlu_model_path:
             agent.interpreter = RasaNLUInterpreter(nlu_model_path)
         else:
-            from rasa_core.interpreter import RegexInterpreter
             agent.interpreter = RegexInterpreter()
         agent.train_online(
                 stories_file,

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -79,7 +79,8 @@ def train_dialogue_model(domain_file, stories_file, output_path,
         agent.train_online(
                 stories_file,
                 input_channel=ConsoleInputChannel(),
-                epochs=10)
+                epochs=10,
+                model_path=output_path)
     else:
         agent.train(
                 stories_file,

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -31,6 +31,11 @@ def create_argument_parser():
             required=True,
             help="domain specification yaml file")
     parser.add_argument(
+            '-u', '--nlu',
+            type=str,
+            default=None,
+            help="trained nlu model")
+    parser.add_argument(
             '-v', '--verbose',
             default=True,
             help="use verbose logging")
@@ -47,6 +52,12 @@ def create_argument_parser():
             default=20,
             help="number of training samples to put into one training batch")
     parser.add_argument(
+            '--online',
+            default=False,
+            action='store_const',
+            const=True,
+            help="enable online training")
+    parser.add_argument(
             '--augmentation',
             default=50,
             help="how much data augmentation to use during training")
@@ -54,14 +65,28 @@ def create_argument_parser():
     return parser
 
 
-def train_dialogue_model(domain_file, stories_file, output_path, kwargs):
+def train_dialogue_model(domain_file, stories_file, output_path,
+                         online, nlu_model_path, kwargs):
     agent = Agent(domain_file, policies=[MemoizationPolicy(), KerasPolicy()])
 
-    agent.train(
-            stories_file,
-            validation_split=0.1,
-            **kwargs
-    )
+    if online:
+        from rasa_core.channels.console import ConsoleInputChannel
+        from rasa_core.interpreter import RasaNLUInterpreter
+        if nlu_model_path:
+            agent.interpreter = RasaNLUInterpreter(nlu_model_path)
+        else:
+            from rasa_core.interpreter import RegexInterpreter
+            agent.interpreter = RegexInterpreter()
+        agent.train_online(
+                stories_file,
+                input_channel=ConsoleInputChannel(),
+                epochs=10)
+    else:
+        agent.train(
+                stories_file,
+                validation_split=0.1,
+                **kwargs
+        )
 
     agent.persist(output_path)
 
@@ -84,4 +109,6 @@ if __name__ == '__main__':
     train_dialogue_model(cmdline_args.domain,
                          cmdline_args.stories,
                          cmdline_args.out,
+                         cmdline_args.online,
+                         cmdline_args.nlu,
                          additional_arguments)


### PR DESCRIPTION
**Proposed changes**:
- allows to use the `train.py` script to start online learning using the `--online` flag

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
