### PR TITLE
accepting remove_duplicates as a parameter to agent.train

### DIFF
--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -135,7 +135,7 @@ class Agent(object):
             if type(p) == MemoizationPolicy:
                 p.toggle(activate)
 
-    def train(self, filename=None, model_path=None, **kwargs):
+    def train(self, filename=None, model_path=None, remove_duplicates=True, **kwargs):
         # type: (Optional[Text], Optional[Text], **Any) -> None
         """Train the policies / policy ensemble using dialogue data from file"""
 

--- a/rasa_core/policies/trainer.py
+++ b/rasa_core/policies/trainer.py
@@ -22,7 +22,7 @@ class PolicyTrainer(object):
 
     def train(self, filename=None, max_history=3,
               augmentation_factor=20, max_training_samples=None,
-              max_number_of_trackers=2000, **kwargs):
+              max_number_of_trackers=2000, remove_duplicates=True, **kwargs):
         """Trains a policy on a domain using training data from a file.
 
         :param augmentation_factor: how many stories should be created by
@@ -34,6 +34,8 @@ class PolicyTrainer(object):
                                      train on - `None` to use all examples
         :param max_number_of_trackers: limits the tracker generation during
                                        story file parsing - `None` for unlimited
+        :param remove_duplicates: remove duplicates from the training set before
+                                  training
         :param kwargs: additional arguments passed to the underlying ML trainer
                        (e.g. keras parameters)
         :return: trained policy
@@ -45,13 +47,15 @@ class PolicyTrainer(object):
         X, y = self._prepare_training_data(filename, max_history,
                                            augmentation_factor,
                                            max_training_samples,
-                                           max_number_of_trackers)
+                                           max_number_of_trackers,
+                                           remove_duplicates)
 
         self.ensemble.train(X, y, self.domain, self.featurizer, **kwargs)
 
     def _prepare_training_data(self, filename, max_history, augmentation_factor,
                                max_training_samples=None,
-                               max_number_of_trackers=2000):
+                               max_number_of_trackers=2000,
+                               remove_duplicates=True):
         """Reads training data from file and prepares it for the training."""
 
         from rasa_core.training_utils import extract_training_data_from_file
@@ -61,7 +65,7 @@ class PolicyTrainer(object):
                     filename,
                     augmentation_factor=augmentation_factor,
                     max_history=max_history,
-                    remove_duplicates=True,
+                    remove_duplicates=remove_duplicates,
                     domain=self.domain,
                     featurizer=self.featurizer,
                     interpreter=RegexInterpreter(),


### PR DESCRIPTION
**Proposed changes**:
- #54 `remove_duplicates` can be passed to `agent.train`

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog

Is this PR about what you had in mind when formulating #54?
If not maybe you can give me some more insight on how you imagined this change to be :)
If yes I will move on to satisfy further contribution guidelines!

(Off-Topic: Hey Joey, I loved your talk on PyCon.DE!)