### PR TITLE
Fix interpreter doc format

### DIFF
--- a/docs/interpreters.rst
+++ b/docs/interpreters.rst
@@ -18,7 +18,10 @@ which has a method ``parse(message)`` which takes a single string argument and r
 
     {
       "text": "show me chinese restaurants",
-      "intent": "restaurant_search",
+      "intent": {
+        "name": "restaurant_search",
+        "confidence": 1.0
+      }
       "entities": [
         {
           "start": 8,


### PR DESCRIPTION
**Proposed changes**:

Fix documentation for Interpreter's return format. **intent** should be a dictionary containing **name** and **confidence**. In the current documentation, the example **intent** provided is a string that will cause `AttributeError: 'str' object has no attribute 'get'` error.

**Status**:
- [x] updated the documentation
