### PR TITLE
Entity retrieval

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 
 Added
 -----
+- added method to tracker to retrieve the latest entities #68
 
 Changed
 -------

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -10,7 +10,7 @@ from collections import deque
 
 import jsonpickle
 import typing
-from typing import Generator, Dict, Text, Any, Optional
+from typing import Generator, Dict, Text, Any, Optional, Union
 from typing import List
 
 from rasa_core import utils
@@ -92,6 +92,16 @@ class DialogueStateTracker(object):
         else:
             logger.info("Tried to access non existent slot '{}'".format(key))
             return None
+
+    def get_latest_entity_values(self, entity_name):
+        # type: (Text) -> List[Text]
+        """Get entity values found for the passed entity name in latest msg."""
+
+        entity_values = [x.get("value")
+                         for x in self.latest_message.entities
+                         if x.get("entity") == entity_name]
+
+        return entity_values
 
     def is_paused(self):
         # type: () -> bool

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -10,7 +10,7 @@ from collections import deque
 
 import jsonpickle
 import typing
-from typing import Generator, Dict, Text, Any, Optional, Union
+from typing import Generator, Dict, Text, Any, Optional
 from typing import List
 
 from rasa_core import utils

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -120,6 +120,26 @@ def test_tracker_state_regression(default_agent):
     assert ";".join([e.as_story_string() for e in tracker.events]) == expected
 
 
+def test_tracker_entity_retrieval(default_domain):
+    tracker = DialogueStateTracker("default", default_domain.slots,
+                                   default_domain.topics,
+                                   default_domain.default_topic)
+    # the retrieved tracker should be empty
+    assert len(tracker.events) == 0
+
+    intent = {"name": "greet", "confidence": 1.0}
+    assert tracker.get_latest_entity_values("entity_name") == []
+    tracker.update(UserUttered("_greet", intent, [{
+          "start": 1,
+          "end": 5,
+          "value": "greet",
+          "entity": "entity_name",
+          "extractor": "manual"
+        }]))
+    assert tracker.get_latest_entity_values("entity_name") == ["greet"]
+    assert tracker.get_latest_entity_values("unknown") == []
+
+
 def test_restart_event(default_domain):
     tracker = DialogueStateTracker("default", default_domain.slots,
                                    default_domain.topics,

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -126,9 +126,9 @@ def test_tracker_entity_retrieval(default_domain):
                                    default_domain.default_topic)
     # the retrieved tracker should be empty
     assert len(tracker.events) == 0
+    assert tracker.get_latest_entity_values("entity_name") == []
 
     intent = {"name": "greet", "confidence": 1.0}
-    assert tracker.get_latest_entity_values("entity_name") == []
     tracker.update(UserUttered("_greet", intent, [{
           "start": 1,
           "end": 5,


### PR DESCRIPTION
**Proposed changes**:
- adds a method to the tracker to retrieve the values for an entity from the latest message, e.g. `tracker.get_latest_entity_values("number")` will be `["3"]`
- related to #68
**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
