### PR TITLE
change the api name of updating events

### DIFF
--- a/docs/state.rst
+++ b/docs/state.rst
@@ -4,7 +4,7 @@ Tracking Conversation State
 ===========================
 
 The ``DialogueStateTracker`` is the stateful object which keeps track of a conversation. 
-The only way the tracker should ever be updated is by passing ``events`` to the ``log_event`` method.
+The only way the tracker should ever be updated is by passing ``events`` to the ``update`` method.
 For example:
 
 .. doctest::


### PR DESCRIPTION
original phrase: 
> by passing ``events`` to the ``log_event`` method
changed to:
> by passing ``events`` to the ``update`` method

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
