### PR TITLE
issue56: 'sender' to 'sender_id', 'default' by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 
 Changed
 -------
+- "sender_id" (and "DEFAULT_SENDER_ID") keyword consistency issue #56
 
 Removed
 -------

--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -61,7 +61,7 @@ class Agent(object):
             text_message,  # type: Text
             message_preprocessor=None,  # type: Optional[Callable[[Text], Text]]
             output_channel=None,  # type: Optional[OutputChannel]
-            sender=None  # type: Optional[Text]
+            sender_id="default"  # type: Optional[Text]
     ):
         # type: (...) -> Optional[List[Text]]
         """
@@ -91,16 +91,16 @@ class Agent(object):
 
         processor = self._create_processor(message_preprocessor)
         return processor.handle_message(
-                UserMessage(text_message, output_channel, sender))
+                UserMessage(text_message, output_channel, sender_id))
 
     def start_message_handling(self,
                                text_message,
-                               sender=None):
+                               sender_id="default"):
         # type: (Text, Optional[Text]) -> Dict[Text, Any]
 
         processor = self._create_processor()
         return processor.start_message_handling(
-                UserMessage(text_message, None, sender))
+                UserMessage(text_message, None, sender_id))
 
     def continue_message_handling(self, sender_id, executed_action, events):
         # type: (Text, Text, List[Event]) -> Dict[Text, Any]

--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -61,7 +61,7 @@ class Agent(object):
             text_message,  # type: Text
             message_preprocessor=None,  # type: Optional[Callable[[Text], Text]]
             output_channel=None,  # type: Optional[OutputChannel]
-            sender_id="default"  # type: Optional[Text]
+            sender_id=UserMessage.DEFAULT_SENDER_ID  # type: Optional[Text]
     ):
         # type: (...) -> Optional[List[Text]]
         """
@@ -95,7 +95,7 @@ class Agent(object):
 
     def start_message_handling(self,
                                text_message,
-                               sender_id="default"):
+                               sender_id=UserMessage.DEFAULT_SENDER_ID):
         # type: (Text, Optional[Text]) -> Dict[Text, Any]
 
         processor = self._create_processor()

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -13,7 +13,7 @@ class UserMessage(object):
 
      Includes the channel the responses should be sent to."""
 
-    DEFAULT_SENDER = "default"
+    DEFAULT_SENDER_ID = "default"
 
     def __init__(self, text, output_channel=None, sender_id=None):
         # type: (Optional[Text], Optional[OutputChannel], Text) -> None
@@ -29,7 +29,7 @@ class UserMessage(object):
         if sender_id is not None:
             self.sender_id = sender_id
         else:
-            self.sender_id = self.DEFAULT_SENDER
+            self.sender_id = self.DEFAULT_SENDER_ID
 
 
 class InputChannel(object):

--- a/rasa_core/channels/custom.py
+++ b/rasa_core/channels/custom.py
@@ -55,9 +55,9 @@ class CustomInput(HttpInputComponent):
         @custom_webhook.route("/webhook", methods=['POST'])
         def receive():
             payload = request.json
-            sender = payload.get("sender", None)
+            sender_id = payload.get("sender", None)
             text = payload.get("message", None)
-            on_new_message(UserMessage(text, self.out_channel, sender))
+            on_new_message(UserMessage(text, self.out_channel, sender_id))
             return "success"
 
         return custom_webhook

--- a/rasa_core/channels/facebook.py
+++ b/rasa_core/channels/facebook.py
@@ -109,10 +109,10 @@ class FacebookInput(HttpInputComponent):
                     else:
                         continue
                     try:
-                        sender = x['sender']['id']
+                        sender_id = x['sender']['id']
                         if page_id in self.fb_tokens:
                             out_channel = MessengerBot(self.fb_tokens[page_id])
-                            user_msg = UserMessage(text, out_channel, sender)
+                            user_msg = UserMessage(text, out_channel, sender_id)
                             on_new_message(user_msg)
                         else:
                             raise Exception("Unknown page id '{}'. Make sure to"

--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -32,10 +32,10 @@ class Button(dict):
 class Dispatcher(object):
     """Send messages back to user"""
 
-    def __init__(self, sender, output_channel, domain):
+    def __init__(self, sender_id, output_channel, domain):
         # type: (Text, OutputChannel, Domain) -> None
 
-        self.sender = sender
+        self.sender_id = sender_id
         self.output_channel = output_channel
         self.domain = domain
         self.send_messages = []
@@ -58,28 +58,28 @@ class Dispatcher(object):
         # type: (Text) -> None
         """"Send a text to the output channel"""
 
-        if self.sender is not None and self.output_channel is not None:
+        if self.sender_id is not None and self.output_channel is not None:
             for message_part in text.split("\n\n"):
-                self.output_channel.send_text_message(self.sender, message_part)
+                self.output_channel.send_text_message(self.sender_id, message_part)
                 self.send_messages.append(message_part)
 
     def utter_custom_message(self, *elements):
         # type: (*Dict[Text, Any]) -> None
         """Sends a message with custom elements to the output channel."""
 
-        self.output_channel.send_custom_message(self.sender, elements)
+        self.output_channel.send_custom_message(self.sender_id, elements)
 
     def utter_button_message(self, text, buttons, **kwargs):
         # type: (Text, List[Dict[Text, Any]], **Any) -> None
         """Sends a message with buttons to the output channel."""
 
-        self.output_channel.send_text_with_buttons(self.sender, text, buttons,
+        self.output_channel.send_text_with_buttons(self.sender_id, text, buttons,
                                                    **kwargs)
 
     def utter_attachment(self, attachment):
         # type: (Text) -> None
         """Send a message to the client with attachments."""
-        self.output_channel.send_image_url(self.sender, attachment)
+        self.output_channel.send_image_url(self.sender_id, attachment)
 
     def utter_button_template(self, template, buttons, filled_slots=None, **kwargs):
         # type: (Text, List[Dict[Text, Any]], **Any) -> None

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -112,9 +112,9 @@ def collect_story_predictions(story_file, policy_model_path, nlu_model_path,
     logger.info("Evaluating {} stories\nProgress:".format(len(stories)))
 
     for s in tqdm(stories):
-        sender = "default-" + uuid.uuid4().hex
+        sender_id = "default-" + uuid.uuid4().hex
 
-        dialogue = s.as_dialogue(sender, agent.domain)
+        dialogue = s.as_dialogue(sender_id, agent.domain)
         actions_between_utterances = []
         last_prediction = []
 
@@ -126,8 +126,8 @@ def collect_story_predictions(story_file, policy_model_path, nlu_model_path,
                 actual.extend(a)
 
                 actions_between_utterances = []
-                agent.handle_message(event.text, sender=sender)
-                tracker = agent.tracker_store.retrieve(sender)
+                agent.handle_message(event.text, sender_id=sender_id)
+                tracker = agent.tracker_store.retrieve(sender_id)
                 last_prediction = actions_since_last_utterance(tracker)
 
             elif isinstance(event, ActionExecuted):

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -160,7 +160,7 @@ class MessageProcessor(object):
                     return True
             return True  # tracker has probably been restarted
 
-        tracker = self._get_tracker(dispatcher.sender)
+        tracker = self._get_tracker(dispatcher.sender_id)
 
         if (reminder_event.kill_on_user_message and
                 has_message_after_reminder(tracker)):
@@ -176,7 +176,7 @@ class MessageProcessor(object):
             if should_continue:
                 user_msg = UserMessage(None,
                                        dispatcher.output_channel,
-                                       dispatcher.sender)
+                                       dispatcher.sender_id)
                 self._predict_and_execute_next_action(user_msg, tracker)
             # save tracker state to continue conversation from this state
             self._save_tracker(tracker)
@@ -306,10 +306,10 @@ class MessageProcessor(object):
         for e in events:
             tracker.update(e)
 
-    def _get_tracker(self, sender):
+    def _get_tracker(self, sender_id):
         # type: (Text) -> DialogueStateTracker
 
-        sender_id = sender or UserMessage.DEFAULT_SENDER
+        sender_id = sender_id or UserMessage.DEFAULT_SENDER_ID
         tracker = self.tracker_store.get_or_create_tracker(sender_id)
         return tracker
 

--- a/rasa_core/tracker_store.py
+++ b/rasa_core/tracker_store.py
@@ -31,7 +31,7 @@ class TrackerStore(object):
                                        self.domain.default_topic)
 
     def create_tracker(self, sender_id):
-        """Creates a new tracker for the sender.
+        """Creates a new tracker for the sender_id.
 
         The tracker is initially listening."""
 

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -141,7 +141,7 @@ class DialogueStateTracker(object):
         The resulting array is representing the state before each action."""
         from rasa_core.channels import UserMessage
 
-        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER,
+        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER_ID,
                                        self.slots.values(),
                                        self.topics,
                                        self.default_topic)

--- a/rasa_core/training_utils/dsl.py
+++ b/rasa_core/training_utils/dsl.py
@@ -253,7 +253,7 @@ class Story(object):
     def __init__(self, story_steps=None):
         self.story_steps = story_steps if story_steps else []
 
-    def as_dialogue(self, sender, domain):
+    def as_dialogue(self, sender_id, domain):
         events = []
         for step in self.story_steps:
             events.extend(
@@ -261,7 +261,7 @@ class Story(object):
                                          should_append_final_listen=False))
 
         events.append(ActionExecuted(ActionListen().name()))
-        return Dialogue(sender, events)
+        return Dialogue(sender_id, events)
 
     def as_story_string(self, flat=False):
         story_content = ""
@@ -471,7 +471,7 @@ class FeaturizedTracker(object):
         # type: (Domain, int) -> FeaturizedTracker
         """Creates a featurized tracker from a domain."""
 
-        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER,
+        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER_ID,
                                        domain.slots,
                                        domain.topics,
                                        domain.default_topic,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -39,5 +39,5 @@ def test_agent_train(tmpdir, default_domain):
 
 def test_agent_handle_message(default_agent):
     result = default_agent.handle_message("_greet[name=Rasa]",
-                                          sender="test_agent_handle_message")
+                                          sender_id="test_agent_handle_message")
     assert result == ["hey there Rasa!"]

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -70,7 +70,7 @@ class PolicyTestCollection(object):
             assert predicted_probabilities == actual_probabilities
 
     def test_prediction_on_empty_tracker(self, trained_policy, default_domain):
-        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER,
+        tracker = DialogueStateTracker(UserMessage.DEFAULT_SENDER_ID,
                                        default_domain.slots,
                                        default_domain.topics,
                                        default_domain.default_topic)

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -106,11 +106,11 @@ def test_tracker_write_to_story(tmpdir, default_domain):
 
 
 def test_tracker_state_regression(default_agent):
-    sender = "test_tracker_state_regression"
+    sender_id = "test_tracker_state_regression"
     n_actions = []
     for i in range(0, 2):
-        default_agent.handle_message("_greet", sender=sender)
-    tracker = default_agent.tracker_store.get_or_create_tracker(sender)
+        default_agent.handle_message("_greet", sender_id=sender_id)
+    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
 
     # Ensures that the tracker has changed between the utterances
     # (and wasn't reset in between them)


### PR DESCRIPTION
**Proposed changes**:
See https://github.com/RasaHQ/rasa_core/issues/56. For ten python scripts (as well as some in tests folder):
"sender" is renamed as "sender_id";
"DEFAULT_SENDER" is renamed as "DEFAULT_SENDER_ID";
"sender" is set to DEFAULT_SENDER_ID (= "default")

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
