### PR TITLE
WIP: logging all bot utterances in the tracker

### DIFF
--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -103,8 +103,6 @@ class Dispatcher(object):
             t["buttons"] = buttons
         else:
             t["buttons"].extend(buttons)
-        self.latest_bot_messages.append(BotMessage(text=t["text"],
-                                                   data={"buttons": t["buttons"]}))
         self.utter_response(t)
 
     def utter_template(self, template, filled_slots=None, **kwargs):
@@ -112,8 +110,6 @@ class Dispatcher(object):
         """"Send a message to the client based on a template."""
 
         message = self.retrieve_template(template, filled_slots, **kwargs)
-        self.latest_bot_messages.append(BotMessage(text=message["text"],
-                                                   data=None))
         self.utter_response(message)
 
     @staticmethod

--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 import copy
 
 from typing import Text, List, Dict, Any
+from collections import namedtuple
+
 import copy
 
 from rasa_core.domain import Domain
@@ -24,15 +26,7 @@ class Element(dict):
         super(Element, self).__init__(*args, **kwargs)
 
 
-class BotMessage(dict):
-    __acceptable_keys = ['text', 'data']
-
-    def __init__(self, *args, **kwargs):
-        kwargs = {key: value
-                  for key, value in kwargs.items()
-                  if key in self.__acceptable_keys}
-
-        super(BotMessage, self).__init__(*args, **kwargs)
+BotMessage = namedtuple("BotMessage", "text data")
 
 
 class Button(dict):
@@ -50,7 +44,7 @@ class Dispatcher(object):
         self.output_channel = output_channel
         self.domain = domain
         self.send_messages = []
-        self.bot_message = None
+        self.latest_bot_messages = []
 
     def utter_response(self, message):
         # type: (Dict[Text, Any]) -> None
@@ -70,8 +64,8 @@ class Dispatcher(object):
         # type: (Text) -> None
         """"Send a text to the output channel"""
 
-        self.bot_message = BotMessage(text=text,
-                                      data=None)
+        self.latest_bot_messages.append(BotMessage(text=text,
+                                                   data=None))
         if self.sender_id is not None and self.output_channel is not None:
             for message_part in text.split("\n\n"):
                 self.output_channel.send_text_message(self.sender_id, message_part)
@@ -81,23 +75,23 @@ class Dispatcher(object):
         # type: (*Dict[Text, Any]) -> None
         """Sends a message with custom elements to the output channel."""
 
-        self.bot_message = BotMessage(text=None,
-                                      data={"elements": elements})
+        self.latest_bot_messages.append(BotMessage(text=None,
+                                                   data={"elements": elements}))
         self.output_channel.send_custom_message(self.sender_id, elements)
 
     def utter_button_message(self, text, buttons, **kwargs):
         # type: (Text, List[Dict[Text, Any]], **Any) -> None
         """Sends a message with buttons to the output channel."""
-        self.bot_message = BotMessage(text=None,
-                                      data={"buttons": buttons})
+        self.latest_bot_messages.append(BotMessage(text=None,
+                                                   data={"buttons": buttons}))
         self.output_channel.send_text_with_buttons(self.sender_id, text, buttons,
                                                    **kwargs)
 
     def utter_attachment(self, attachment):
         # type: (Text) -> None
         """Send a message to the client with attachments."""
-        self.bot_message = BotMessage(text=None,
-                                      data={"attachment": attachment})
+        self.latest_bot_messages.append(BotMessage(text=None,
+                                                   data={"attachment": attachment}))
         self.output_channel.send_image_url(self.sender_id, attachment)
 
     def utter_button_template(self, template, buttons, filled_slots=None, **kwargs):
@@ -109,8 +103,8 @@ class Dispatcher(object):
             t["buttons"] = buttons
         else:
             t["buttons"].extend(buttons)
-        self.bot_message = BotMessage(text=t["text"],
-                                      data={"buttons": t["buttons"]})
+        self.latest_bot_messages.append(BotMessage(text=t["text"],
+                                                   data={"buttons": t["buttons"]}))
         self.utter_response(t)
 
     def utter_template(self, template, filled_slots=None, **kwargs):
@@ -118,8 +112,8 @@ class Dispatcher(object):
         """"Send a message to the client based on a template."""
 
         message = self.retrieve_template(template, filled_slots, **kwargs)
-        self.bot_message = BotMessage(text=message["text"],
-                                      data=None)
+        self.latest_bot_messages.append(BotMessage(text=message["text"],
+                                                   data=None))
         self.utter_response(message)
 
     @staticmethod

--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -24,6 +24,17 @@ class Element(dict):
         super(Element, self).__init__(*args, **kwargs)
 
 
+class BotMessage(dict):
+    __acceptable_keys = ['text', 'data']
+
+    def __init__(self, *args, **kwargs):
+        kwargs = {key: value
+                  for key, value in kwargs.items()
+                  if key in self.__acceptable_keys}
+
+        super(BotMessage, self).__init__(*args, **kwargs)
+
+
 class Button(dict):
     # TODO: Decide if this should do more
     pass
@@ -39,6 +50,7 @@ class Dispatcher(object):
         self.output_channel = output_channel
         self.domain = domain
         self.send_messages = []
+        self.bot_message = None
 
     def utter_response(self, message):
         # type: (Dict[Text, Any]) -> None
@@ -58,6 +70,8 @@ class Dispatcher(object):
         # type: (Text) -> None
         """"Send a text to the output channel"""
 
+        self.bot_message = BotMessage(text=text,
+                                      data=None)
         if self.sender_id is not None and self.output_channel is not None:
             for message_part in text.split("\n\n"):
                 self.output_channel.send_text_message(self.sender_id, message_part)
@@ -67,18 +81,23 @@ class Dispatcher(object):
         # type: (*Dict[Text, Any]) -> None
         """Sends a message with custom elements to the output channel."""
 
+        self.bot_message = BotMessage(text=None,
+                                      data={"elements": elements})
         self.output_channel.send_custom_message(self.sender_id, elements)
 
     def utter_button_message(self, text, buttons, **kwargs):
         # type: (Text, List[Dict[Text, Any]], **Any) -> None
         """Sends a message with buttons to the output channel."""
-
+        self.bot_message = BotMessage(text=None,
+                                      data={"buttons": buttons})
         self.output_channel.send_text_with_buttons(self.sender_id, text, buttons,
                                                    **kwargs)
 
     def utter_attachment(self, attachment):
         # type: (Text) -> None
         """Send a message to the client with attachments."""
+        self.bot_message = BotMessage(text=None,
+                                      data={"attachment": attachment})
         self.output_channel.send_image_url(self.sender_id, attachment)
 
     def utter_button_template(self, template, buttons, filled_slots=None, **kwargs):
@@ -90,6 +109,8 @@ class Dispatcher(object):
             t["buttons"] = buttons
         else:
             t["buttons"].extend(buttons)
+        self.bot_message = BotMessage(text=t["text"],
+                                      data={"buttons": t["buttons"]})
         self.utter_response(t)
 
     def utter_template(self, template, filled_slots=None, **kwargs):
@@ -97,6 +118,8 @@ class Dispatcher(object):
         """"Send a message to the client based on a template."""
 
         message = self.retrieve_template(template, filled_slots, **kwargs)
+        self.bot_message = BotMessage(text=message["text"],
+                                      data=None)
         self.utter_response(message)
 
     @staticmethod

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -159,8 +159,8 @@ class BotUttered(Event):
     type_name = "bot"
 
     def __init__(self, text=None, data=None):
-        self.text = text if text else []
-        self.data = data if data else []
+        self.text = text
+        self.data = data
 
     def __hash__(self):
         return hash((self.text, self.data))

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -159,8 +159,8 @@ class BotUttered(Event):
     type_name = "bot"
 
     def __init__(self, text=None, data=None):
-        self.text = text if text else ""
-        self.data = data if data else {}
+        self.text = text if text else []
+        self.data = data if data else []
 
     def __hash__(self):
         return hash((self.text, self.data))

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -26,7 +26,7 @@ class Event(object):
     - the topic has been set
     - the bot has taken an action
 
-    Events are logged by the Tracker's log_event method.
+    Events are logged by the Tracker's update method.
     This updates the list of turns so that the current state
     can be recovered by consuming the list of turns."""
 
@@ -146,6 +146,42 @@ class UserUttered(Event):
         # type: (DialogueStateTracker) -> None
 
         tracker.latest_message = self
+
+
+# noinspection PyProtectedMember
+class BotUttered(Event):
+    """The bot has said something to the user.
+
+    This class is not used in the story training as it is contained in the
+
+    ```ActionExecuted class```. An entry is made in the ``Tracker``."""
+
+    def __init__(self, text=None, data=None):
+        self.text = text if text else ""
+        self.data = data if data else {}
+
+    def __hash__(self):
+        return hash((self.text, self.data))
+
+    def __eq__(self, other):
+        if not isinstance(other, BotUttered):
+            return False
+        else:
+            return (self.text, self.data) == \
+                   (other.text, other.data)
+
+    def __str__(self):
+        return "BotUttered(text: {}, data: {})".format(self.text, json.dumps(self.data, indent=2))
+
+    def apply_to(self, tracker):
+        # type: (DialogueStateTracker) -> None
+
+        tracker.latest_bot_message = self
+
+    def as_story_string(self):
+        logger.debug("BotUttered event for {} need not be featurized. "
+                     "Use an ActionExecuted instead.".format(self.text))
+        raise NotImplementedError
 
 
 # noinspection PyProtectedMember

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -183,6 +183,10 @@ class BotUttered(Event):
     def as_story_string(self):
         return None
 
+    @staticmethod
+    def empty():
+        return BotUttered()
+
     @classmethod
     def _from_parameters(cls, event_name, parameters, domain):
         try:

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -154,7 +154,9 @@ class BotUttered(Event):
 
     This class is not used in the story training as it is contained in the
 
-    ```ActionExecuted class```. An entry is made in the ``Tracker``."""
+    ``ActionExecuted`` class. An entry is made in the ``Tracker``."""
+
+    type_name = "bot"
 
     def __init__(self, text=None, data=None):
         self.text = text if text else ""
@@ -176,12 +178,17 @@ class BotUttered(Event):
     def apply_to(self, tracker):
         # type: (DialogueStateTracker) -> None
 
-        tracker.latest_bot_message = self
+        tracker.latest_bot_utterance = self
 
     def as_story_string(self):
-        logger.debug("BotUttered event for {} need not be featurized. "
-                     "Use an ActionExecuted instead.".format(self.text))
-        raise NotImplementedError
+        return None
+
+    @classmethod
+    def _from_parameters(cls, event_name, parameters, domain):
+        try:
+            return BotUttered(parameters["text"], parameters["data"])
+        except KeyError as e:
+            raise ValueError("Failed to parse bot uttered event. {}".format(e))
 
 
 # noinspection PyProtectedMember

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -286,8 +286,8 @@ class MessageProcessor(object):
                          "code.".format(action.name()), )
             logger.error(e, exc_info=True)
             events = []
-        self._log_action_on_tracker(tracker, action.name(), events)
         self._log_bot_utterances_on_tracker(tracker, dispatcher)
+        self._log_action_on_tracker(tracker, action.name(), events)
         self._schedule_reminders(events, dispatcher)
 
         return self._should_predict_another_action(action.name(), events)
@@ -295,15 +295,17 @@ class MessageProcessor(object):
     def _log_bot_utterances_on_tracker(self, tracker, dispatcher):
         # type: (DialogueStateTracker, Dispatcher) -> None
 
-        if dispatcher.bot_message is not None:
-            text = dispatcher.bot_message.get("text")
-            data = dispatcher.bot_message.get("data")
+        if dispatcher.latest_bot_messages:
+            text = dispatcher.latest_bot_messages.get("text")
+            data = dispatcher.latest_bot_messages.get("data")
 
             bot_utterance = BotUttered(text=text, data=data)
 
             logger.debug("Bot utterance '{}'".format(bot_utterance))
 
             tracker.update(bot_utterance)
+
+            dispatcher.latest_bot_messages = []
 
     def _log_action_on_tracker(self, tracker, action_name, events):
         # Ensures that the code still works even if a lazy programmer missed

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -296,20 +296,10 @@ class MessageProcessor(object):
         # type: (DialogueStateTracker, Dispatcher) -> None
 
         if dispatcher.latest_bot_messages:
-            text = []
-            data = []
-
             for m in dispatcher.latest_bot_messages:
-                if m["text"]:
-                    text.append(m["text"])
-                if m["data"]:
-                    data.append(m["data"])
-
-            bot_utterance = BotUttered(text=text, data=data)
-
-            logger.debug("Bot utterance '{}'".format(bot_utterance))
-
-            tracker.update(bot_utterance)
+                bot_utterance = BotUttered(text=m.text, data=m.data)
+                logger.debug("Bot utterance '{}'".format(bot_utterance))
+                tracker.update(bot_utterance)
 
             dispatcher.latest_bot_messages = []
 

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -296,8 +296,14 @@ class MessageProcessor(object):
         # type: (DialogueStateTracker, Dispatcher) -> None
 
         if dispatcher.latest_bot_messages:
-            text = dispatcher.latest_bot_messages.get("text")
-            data = dispatcher.latest_bot_messages.get("data")
+            text = []
+            data = []
+
+            for m in dispatcher.latest_bot_messages:
+                if m["text"]:
+                    text.append(m["text"])
+                if m["data"]:
+                    data.append(m["data"])
 
             bot_utterance = BotUttered(text=text, data=data)
 

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -16,7 +16,7 @@ from typing import List
 from rasa_core import utils
 from rasa_core.conversation import Dialogue
 from rasa_core.events import UserUttered, TopicSet, ActionExecuted, \
-    Event, SlotSet, Restarted, ActionReverted, UserUtteranceReverted
+    Event, SlotSet, Restarted, ActionReverted, UserUtteranceReverted, BotUttered
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,7 @@ class DialogueStateTracker(object):
         self._topic_stack = None
         self.latest_action_name = None
         self.latest_message = None
+        self.latest_bot_utterance = None
         self.latest_restart_event = None
         self._reset()
 
@@ -247,6 +248,7 @@ class DialogueStateTracker(object):
         self._paused = False
         self.latest_action_name = None
         self.latest_message = UserUttered.empty()
+        self.latest_bot_utterance = BotUttered.empty()
         self.follow_up_action = None
         self._topic_stack = utils.TopicStack(self.topics, [],
                                              self.default_topic)

--- a/rasa_core/training_utils/dsl.py
+++ b/rasa_core/training_utils/dsl.py
@@ -25,7 +25,7 @@ from rasa_core.channels import UserMessage
 from rasa_core.conversation import Dialogue
 from rasa_core.domain import Domain
 from rasa_core.events import ActionExecuted, UserUttered, Event, \
-    ActionReverted, BotUttered
+    ActionReverted
 from rasa_core.featurizers import Featurizer
 from rasa_core.interpreter import RegexInterpreter, NaturalLanguageInterpreter
 from rasa_core.trackers import DialogueStateTracker

--- a/rasa_core/training_utils/dsl.py
+++ b/rasa_core/training_utils/dsl.py
@@ -128,10 +128,10 @@ class StoryStep(object):
         for s in self.events:
             if isinstance(s, UserUttered):
                 result += "* {}\n".format(s.as_story_string())
-            elif isinstance(s, BotUttered):
-                continue
             elif isinstance(s, Event):
-                result += "    - {}\n".format(s.as_story_string())
+                converted = s.as_story_string()
+                if converted:
+                    result += "    - {}\n".format(s.as_story_string())
             else:
                 raise Exception("Unexpected element in story step: " + s)
 

--- a/rasa_core/training_utils/dsl.py
+++ b/rasa_core/training_utils/dsl.py
@@ -25,7 +25,7 @@ from rasa_core.channels import UserMessage
 from rasa_core.conversation import Dialogue
 from rasa_core.domain import Domain
 from rasa_core.events import ActionExecuted, UserUttered, Event, \
-    ActionReverted
+    ActionReverted, BotUttered
 from rasa_core.featurizers import Featurizer
 from rasa_core.interpreter import RegexInterpreter, NaturalLanguageInterpreter
 from rasa_core.trackers import DialogueStateTracker
@@ -128,6 +128,8 @@ class StoryStep(object):
         for s in self.events:
             if isinstance(s, UserUttered):
                 result += "* {}\n".format(s.as_story_string())
+            elif isinstance(s, BotUttered):
+                continue
             elif isinstance(s, Event):
                 result += "    - {}\n".format(s.as_story_string())
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,13 @@ from rasa_core.agent import Agent
 from rasa_core.channels.console import ConsoleOutputChannel
 from rasa_core.dispatcher import Dispatcher
 from rasa_core.domain import TemplateDomain
+from rasa_core.featurizers import BinaryFeaturizer
 from rasa_core.interpreter import RegexInterpreter
+from rasa_core.policies import PolicyTrainer
+from rasa_core.policies.ensemble import SimplePolicyEnsemble
 from rasa_core.policies.memoization import MemoizationPolicy
+from rasa_core.policies.scoring_policy import ScoringPolicy
+from rasa_core.processor import MessageProcessor
 from rasa_core.slots import Slot
 from rasa_core.tracker_store import InMemoryTrackerStore
 
@@ -50,3 +55,17 @@ def default_agent(default_domain):
 def default_dispatcher(default_domain):
     bot = ConsoleOutputChannel()
     return Dispatcher("my-sender", bot, default_domain)
+
+
+@pytest.fixture
+def default_processor(default_domain):
+    ensemble = SimplePolicyEnsemble([ScoringPolicy()])
+    interpreter = RegexInterpreter()
+    PolicyTrainer(ensemble, default_domain, BinaryFeaturizer()).train(
+        DEFAULT_STORIES_FILE,
+        max_history=3)
+    tracker_store = InMemoryTrackerStore(default_domain)
+    return MessageProcessor(interpreter,
+                            ensemble,
+                            default_domain,
+                            tracker_store)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,7 +10,7 @@ import pytest
 from rasa_core.events import UserUttered, TopicSet, SlotSet, Restarted, \
     ActionExecuted, AllSlotsReset, \
     ReminderScheduled, ConversationResumed, ConversationPaused, StoryExported, \
-    ActionReverted
+    ActionReverted, BotUttered
 
 
 @pytest.mark.parametrize("one_event,another_event", [
@@ -43,6 +43,9 @@ from rasa_core.events import UserUttered, TopicSet, SlotSet, Restarted, \
 
     (ActionExecuted("my_action"),
      ActionExecuted("my_other_action")),
+
+    (BotUttered("my_text", "my_data"),
+     BotUttered("my_other_test", "my_other_data")),
 
     (ReminderScheduled("my_action", "now"),
      ReminderScheduled("my_other_action", "now")),

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -15,7 +15,9 @@ def test_message_processor(default_processor):
     assert ("default", "hey there Core!") == out.latest_output()
 
 
-def test_logging_of_bot_utterances_on_tracker(default_processor, default_dispatcher, default_agent):
+def test_logging_of_bot_utterances_on_tracker(default_processor,
+                                              default_dispatcher,
+                                              default_agent):
     sender_id = "test_logging_of_bot_utterances_on_tracker"
     tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
     buttons = [
@@ -30,5 +32,6 @@ def test_logging_of_bot_utterances_on_tracker(default_processor, default_dispatc
 
     assert len(default_dispatcher.latest_bot_messages) == 4
 
-    default_processor._log_bot_utterances_on_tracker(tracker, default_dispatcher)
+    default_processor._log_bot_utterances_on_tracker(tracker,
+                                                     default_dispatcher)
     assert not default_dispatcher.latest_bot_messages

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -5,31 +5,30 @@ from __future__ import unicode_literals
 
 from rasa_core.channels import UserMessage
 from rasa_core.channels.direct import CollectingOutputChannel
-from rasa_core.featurizers import BinaryFeaturizer
-from rasa_core.interpreter import RegexInterpreter
-from rasa_core.channels.console import ConsoleOutputChannel
-from rasa_core.policies import PolicyTrainer
-from rasa_core.policies.ensemble import SimplePolicyEnsemble
-from rasa_core.policies.scoring_policy import ScoringPolicy
+from rasa_core.dispatcher import Button, BotMessage
 from rasa_core.processor import MessageProcessor
-from rasa_core.tracker_store import InMemoryTrackerStore
 
 
-def test_message_processor(default_domain, capsys):
-    story_filename = "data/dsl_stories/stories_defaultdomain.md"
-    ensemble = SimplePolicyEnsemble([ScoringPolicy()])
-    interpreter = RegexInterpreter()
-
-    PolicyTrainer(ensemble, default_domain, BinaryFeaturizer()).train(
-            story_filename,
-            max_history=3)
-
-    tracker_store = InMemoryTrackerStore(default_domain)
-    processor = MessageProcessor(interpreter,
-                                 ensemble,
-                                 default_domain,
-                                 tracker_store)
-
+def test_message_processor(default_processor):
     out = CollectingOutputChannel()
-    processor.handle_message(UserMessage("_greet[name=Core]", out))
+    default_processor.handle_message(UserMessage("_greet[name=Core]", out))
     assert ("default", "hey there Core!") == out.latest_output()
+
+
+def test_logging_of_bot_utterances_on_tracker(default_processor, default_dispatcher, default_agent):
+    sender_id = "test_logging_of_bot_utterances_on_tracker"
+    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
+    buttons = [
+        Button(title="Btn1", payload="_btn1"),
+        Button(title="Btn2", payload="_btn2")
+    ]
+
+    default_dispatcher.utter_template("utter_goodbye")
+    default_dispatcher.utter_attachment("http://my-attachment")
+    default_dispatcher.utter_message("my test message")
+    default_dispatcher.utter_button_message("my message", buttons)
+
+    assert len(default_dispatcher.latest_bot_messages) == 4
+
+    default_processor._log_bot_utterances_on_tracker(tracker, default_dispatcher)
+    assert not default_dispatcher.latest_bot_messages

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -116,7 +116,8 @@ def test_tracker_state_regression_without_bot_utterance(default_agent):
     expected = ("action_listen;"
                 "_greet;utter_greet;action_listen;"
                 "_greet;action_listen")
-    assert ";".join([e.as_story_string() for e in tracker.events if e.as_story_string()]) == expected
+    assert ";".join([e.as_story_string() for e in
+                     tracker.events if e.as_story_string()]) == expected
 
 
 def test_tracker_state_regression_with_bot_utterance(default_agent):
@@ -124,7 +125,7 @@ def test_tracker_state_regression_with_bot_utterance(default_agent):
     for i in range(0, 2):
         default_agent.handle_message("_greet", sender_id=sender_id)
     tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
-    
+
     expected = ["action_listen", "_greet", None, "utter_greet",
                 "action_listen", "_greet", "action_listen"]
     print([e.as_story_string() for e in tracker.events])

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -105,9 +105,8 @@ def test_tracker_write_to_story(tmpdir, default_domain):
     assert stories[0].story_steps[0].events[3] == SlotSet("location", "central")
 
 
-def test_tracker_state_regression(default_agent):
-    sender_id = "test_tracker_state_regression"
-    n_actions = []
+def test_tracker_state_regression_without_bot_utterance(default_agent):
+    sender_id = "test_tracker_state_regression_without_bot_utterance"
     for i in range(0, 2):
         default_agent.handle_message("_greet", sender_id=sender_id)
     tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
@@ -117,7 +116,21 @@ def test_tracker_state_regression(default_agent):
     expected = ("action_listen;"
                 "_greet;utter_greet;action_listen;"
                 "_greet;action_listen")
-    assert ";".join([e.as_story_string() for e in tracker.events]) == expected
+    assert ";".join([e.as_story_string() for e in tracker.events if e.as_story_string()]) == expected
+
+
+def test_tracker_state_regression_with_bot_utterance(default_agent):
+    sender_id = "test_tracker_state_regression_with_bot_utterance"
+    for i in range(0, 2):
+        default_agent.handle_message("_greet", sender_id=sender_id)
+    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
+    
+    expected = ["action_listen", "_greet", None, "utter_greet",
+                "action_listen", "_greet", "action_listen"]
+    print([e.as_story_string() for e in tracker.events])
+    for e in tracker.events:
+        print(e)
+    assert [e.as_story_string() for e in tracker.events] == expected
 
 
 def test_tracker_entity_retrieval(default_domain):


### PR DESCRIPTION
**Proposed changes**:
- unfeaturized `BotUttered` event
- this aims to make writing conversation logs easier, as they can be retrieved from the `Tracker`, independent of output channel used (now simply retrieve all `UserUttered` and `BotUttered` events from the tracker when you write out a full log)
- the `Dispatcher` gets a `bot_message`, which holds `text` and `data` (`data` can be anything: a button, a generic element, an image)
- when the `run()` method of an action is called, all bot utterances contained in the `Action`'s `Dispatcher` are written to the tracker

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
