### PR TITLE
Fix json cannot be decoded when OPTIONS is called before POST

### DIFF
--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -97,16 +97,17 @@ class RasaCoreServer(object):
     @app.route("/conversations/<cid>/continue", methods=['POST', 'OPTIONS'])
     @check_cors
     def continue_predicting(self, request, cid):
-        request.setHeader('Content-Type', 'application/json')
-        request_params = json.loads(
-                request.content.read().decode('utf-8', 'strict'))
-        encoded_events = request_params.get("events", [])
-        executed_action = request_params.get("executed_action", None)
-        events = convert_obj_2_tracker_events(encoded_events, self.agent.domain)
-        response = self.agent.continue_message_handling(cid,
-                                                        executed_action,
-                                                        events)
-        return json.dumps(response)
+        if request.method.decode('utf-8', 'strict') == 'POST':
+            request.setHeader('Content-Type', 'application/json')
+            request_params = json.loads(
+                    request.content.read().decode('utf-8', 'strict'))
+            encoded_events = request_params.get("events", [])
+            executed_action = request_params.get("executed_action", None)
+            events = convert_obj_2_tracker_events(encoded_events, self.agent.domain)
+            response = self.agent.continue_message_handling(cid,
+                                                            executed_action,
+                                                            events)
+            return json.dumps(response)
 
     @app.route("/conversations/<cid>/parse", methods=['GET', 'POST', 'OPTIONS'])
     @check_cors


### PR DESCRIPTION
Calling a post with continue endpoint from a browser client I get the following error
exceptions.ValueError: No JSON object could be decoded

This fix is intended to ensure the endpoint if only fully executed when a POST method is called.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
