### PR TITLE
Copy visualization graph before modifying

### DIFF
--- a/rasa_core/training_utils/visualization.py
+++ b/rasa_core/training_utils/visualization.py
@@ -164,12 +164,12 @@ def _merge_equivalent_nodes(G, max_history):
                             _nodes_are_equivalent(G, i, j, max_history):
                         changed = True
                         # moves all outgoing edges to the other node
-                        j_outgoing_edges = G.out_edges(j, keys=True, data=True)
+                        j_outgoing_edges = G.copy().out_edges(j, keys=True, data=True)
                         for _, succ_node, k, d in j_outgoing_edges:
                             _add_edge(G, i, succ_node, k, d.get("label"))
                             G.remove_edge(j, succ_node)
                         # moves all incoming edges to the other node
-                        j_incoming_edges = G.in_edges(j, keys=True, data=True)
+                        j_incoming_edges = G.copy().in_edges(j, keys=True, data=True)
                         for prev_node, _, k, d in j_incoming_edges:
                             _add_edge(G, prev_node, i, k, d.get("label"))
                             G.remove_edge(prev_node, j)
@@ -191,7 +191,7 @@ def _replace_edge_labels_with_nodes(G, next_id, interpreter, training_data,
     else:
         message_generator = None
 
-    for s, e, k, d in G.edges(keys=True, data=True):
+    for s, e, k, d in G.copy().edges(keys=True, data=True):
         if k != EDGE_NONE_LABEL:
             if message_generator and d.get("label", k) is not None:
                 parsed_info = interpreter.parse(d.get("label", k))


### PR DESCRIPTION
Networkx will raise an exception when acccessing neighborhood
dictionaries after modifying the graph:

```
Traceback (most recent call last):
  File "visualize.py", line 9, in <module>
    visualize_stories(stories, "graph.dot")
  File "/home/user/Code/rasa_core/rasa_core/training_utils/visualization.py", line 302, in visualize_stories
    _merge_equivalent_nodes(G, max_history)
  File "/home/user/Code/rasa_core/rasa_core/training_utils/visualization.py", line 168, in _merge_equivalent_nodes
    for _, succ_node, k, d in j_outgoing_edges:
  File "/home/user/anaconda3/envs/frob/lib/python3.6/site-packages/networkx/classes/reportviews.py", line 799, in <genexpr>
    for nbr, kd in nbrs.items() for k, dd in kd.items())
RuntimeError: dictionary changed size during iteration
```

**Proposed changes**:
- Copying the graph before modifying resolves this.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
