### PR TITLE
Fix AttributeError: 'Namespace' object has no attribute 'verbose'

### DIFF
--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -173,7 +173,7 @@ if __name__ == '__main__':
 
     rasa = RasaCoreServer(cmdline_args.core,
                           cmdline_args.nlu,
-                          cmdline_args.verbose,
+                          cmdline_args.loglevel,
                           cmdline_args.log_file,
                           cmdline_args.cors)
 


### PR DESCRIPTION
**Proposed changes**:
- `python -m rasa_core.server -d models/dialogue -u models/nlu/current` is broken and gives an error: `AttributeError: 'Namespace' object has no attribute 'verbose'`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
