### PR TITLE
fixes bug where button message text is set to None

### DIFF
--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -82,7 +82,7 @@ class Dispatcher(object):
     def utter_button_message(self, text, buttons, **kwargs):
         # type: (Text, List[Dict[Text, Any]], **Any) -> None
         """Sends a message with buttons to the output channel."""
-        self.latest_bot_messages.append(BotMessage(text=None,
+        self.latest_bot_messages.append(BotMessage(text=text,
                                                    data={"buttons": buttons}))
         self.output_channel.send_text_with_buttons(self.sender_id, text, buttons,
                                                    **kwargs)


### PR DESCRIPTION
**Proposed changes**:
- pass button message to event rather than forcing `None`.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
