### PR TITLE
Template failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changed
   deprecated)
 - persist action names in domain during model persistence
 - improved travis build speed by not using miniconda
+- don't fail with an exception but with a helpful error message if an
+  utterance template contains a variable that can not be filled
 
 Removed
 -------

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 from types import LambdaType
 
-from typing import Text, List, Dict, Any, Optional
+from typing import Text, List, Dict, Any, Optional, Iterable
 
 
 class UserMessage(object):
@@ -80,7 +80,7 @@ class OutputChannel(object):
             self.send_text_message(recipient_id, button_msg)
 
     def send_custom_message(self, recipient_id, elements):
-        # type: (Text, List[Dict[Text, Any]]) -> None
+        # type: (Text, Iterable[Dict[Text, Any]]) -> None
         """Sends elements to the output.
 
         Default implementation will just post the elements as a string."""

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from rasa_core.channels.console import ConsoleOutputChannel
 from rasa_core.channels.direct import CollectingOutputChannel
 from rasa_core.dispatcher import Button, Element, Dispatcher
 from rasa_core.domain import TemplateDomain
@@ -24,6 +25,20 @@ def test_dispatcher_handle_unknown_template(default_dispatcher_collecting):
     default_dispatcher_collecting.utter_template("my_made_up_template")
     collected = default_dispatcher_collecting.output_channel.latest_output()
     assert collected[1].startswith("Undefined utter template")
+
+
+def test_dispatcher_template_invalid_vars():
+    domain = TemplateDomain(
+            [], [], [], {
+                "my_made_up_template": [{
+                    "text": "a template referencing an invalid {variable}."}]},
+            [], [], None, [])
+    bot = CollectingOutputChannel()
+    dispatcher = Dispatcher("my-sender", bot, domain)
+    dispatcher.utter_template("my_made_up_template")
+    collected = dispatcher.output_channel.latest_output()
+    assert collected[1].startswith(
+            "a template referencing an invalid {variable}.")
 
 
 def test_dispatcher_utter_buttons(default_dispatcher_collecting):


### PR DESCRIPTION
**Proposed changes**:
- if an utterance template contains a variable that can not be filled (because it is neither the name of a slot nor did the user pass a kwarg to fill it) the code handles that gracefully instead of failing with an exception

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
