### PR TITLE
Don't fail on unkown actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Changed
 - improved travis build speed by not using miniconda
 - don't fail with an exception but with a helpful error message if an
   utterance template contains a variable that can not be filled
+- domain doesn't fail on unknown actions but emits a warning instead. this is to support reading 
+  logs from older conversation if one recently removed an action from the domain
 
 Removed
 -------

--- a/rasa_core/domain.py
+++ b/rasa_core/domain.py
@@ -288,7 +288,7 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
                         "Please make sure all actions are listed in the "
                         "domains action list. If you recently removed an "
                         "action, don't worry about this warning. It "
-                        "should stop to appear after a while. "
+                        "should stop appearing after a while. "
                         "".format(latest_action))
         else:
             return {}

--- a/rasa_core/domain.py
+++ b/rasa_core/domain.py
@@ -283,10 +283,13 @@ class Domain(with_metaclass(abc.ABCMeta, object)):
             if prev_action_name in self.input_feature_map:
                 return {prev_action_name: 1}
             else:
-                raise Exception(
+                logger.warn(
                         "Failed to use action '{}' in history. "
                         "Please make sure all actions are listed in the "
-                        "domains action list.".format(latest_action))
+                        "domains action list. If you recently removed an "
+                        "action, don't worry about this warning. It "
+                        "should stop to appear after a while. "
+                        "".format(latest_action))
         else:
             return {}
 


### PR DESCRIPTION
**Proposed changes**:
- e.g. if you remove an action from the domain, logs from the past might still contain that action. so we shouldn't fail here but rather just warn
- for the future we should think wether it makes sense to remove any samples that contain actions that are not part of the domain anymore.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
