### PR TITLE
Bug fix: utter_custom_message never called (to display carousels in Messenger)

### DIFF
--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -51,7 +51,10 @@ class Dispatcher(object):
         # type: (Dict[Text, Any]) -> None
         """Send a message to the client."""
 
-        if message.get("buttons"):
+        if message.get("elements"):
+            self.utter_custom_message(message.get("elements"))
+
+        elif message.get("buttons"):
             self.utter_button_message(message.get("text"),
                                       message.get("buttons"))
         else:


### PR DESCRIPTION
**Proposed changes**:
`utter_custom_message ` is never called on the `Dispatcher` to display carousel objects in Messenger. I just added a condition that looks for an `elements` key in the message and executes `utter_custom_message ` if it finds it

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
