### PR TITLE
calculate restart idx on the fly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,8 @@ Fixed
 - fixed float slot min max value handling
 - fixed non integer feature decoding, e.g. used for memoization policy
 - properly log to specified file when starting Rasa Core server
+- properly calculate offset of last reset event after loading tracker from
+  tracker store
 
 [0.7.9] - 2017-11-29
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -375,8 +375,6 @@ class Restarted(Event):
     def apply_to(self, tracker):
         from rasa_core.actions.action import ActionListen
         tracker._reset()
-        # will be the index of the first event after the restart
-        tracker.latest_restart_event = len(tracker.events) + 1
         tracker.follow_up_action = ActionListen()
 
 

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -64,7 +64,6 @@ class DialogueStateTracker(object):
         self.latest_action_name = None
         self.latest_message = None
         self.latest_bot_utterance = None
-        self.latest_restart_event = None
         self._reset()
 
     ###
@@ -123,14 +122,15 @@ class DialogueStateTracker(object):
         """States whether the tracker is currently paused."""
         return self._paused
 
-    def _idx_after_latest_restart(self):
-        if self.latest_restart_event is not None:
-            return self.latest_restart_event
-        else:
-            return 0
+    def idx_after_latest_restart(self):
+        idx = 0
+        for i, event in enumerate(self.events):
+            if isinstance(event, Restarted):
+                idx = i + 1
+        return idx
 
     def events_after_latest_restart(self):
-        return list(self.events)[self._idx_after_latest_restart():]
+        return list(self.events)[self.idx_after_latest_restart():]
 
     @property
     def previous_topic(self):

--- a/tests/test_tracker_stores.py
+++ b/tests/test_tracker_stores.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 from rasa_core.channels import UserMessage
 from rasa_core.domain import TemplateDomain
-from rasa_core.events import SlotSet
+from rasa_core.events import SlotSet, ActionExecuted, Restarted
 from rasa_core.tracker_store import InMemoryTrackerStore
 
 domain = TemplateDomain.load("data/test_domains/default_with_topic.yml")
@@ -25,3 +25,20 @@ def test_get_or_create():
 
     again = store.get_or_create_tracker(UserMessage.DEFAULT_SENDER_ID)
     assert again.get_slot(slot_key) == slot_val
+
+
+def test_restart_after_retrieval_from_tracker_store(default_domain):
+    store = InMemoryTrackerStore(default_domain)
+    tr = store.get_or_create_tracker("myuser")
+    synth = [ActionExecuted("action_listen") for _ in range(4)]
+
+    for e in synth:
+        tr.update(e)
+
+    tr.update(Restarted())
+    latest_restart = tr.idx_after_latest_restart()
+
+    store.save(tr)
+    tr2 = store.retrieve("myuser")
+    latest_restart_after_loading = tr2.idx_after_latest_restart()
+    assert latest_restart == latest_restart_after_loading


### PR DESCRIPTION
**Proposed changes**:
- idx stored on the tracker is not up to date after loading it from a tracker store --> instead of storing the value on the tracker we will calculate it on the fly when needed.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
