### PR TITLE
Fix UserUtteranceReverted event to include the prior listen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Fixed
 - properly log to specified file when starting Rasa Core server
 - properly calculate offset of last reset event after loading tracker from
   tracker store
+- UserUtteranceReverted action incorrectly triggered actions to be replayed
 
 [0.7.9] - 2017-11-29
 ^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -162,7 +162,6 @@ class DialogueStateTracker(object):
                                        self.default_topic)
 
         for event in self._applied_events():
-            logger.info("Event: {}".format(event))
             if isinstance(event, ActionExecuted):
                 yield tracker
             tracker.update(event)

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -162,6 +162,7 @@ class DialogueStateTracker(object):
                                        self.default_topic)
 
         for event in self._applied_events():
+            logger.info("Event: {}".format(event))
             if isinstance(event, ActionExecuted):
                 yield tracker
             tracker.update(event)
@@ -186,7 +187,12 @@ class DialogueStateTracker(object):
             elif isinstance(event, ActionReverted):
                 undo_till_previous(ActionExecuted, applied_events)
             elif isinstance(event, UserUtteranceReverted):
+                # Seeing a user uttered event automatically implies there was
+                # a listen event right before it, so we'll first rewind the
+                # user utterance, then get the action right before it (the
+                # listen action).
                 undo_till_previous(UserUttered, applied_events)
+                undo_till_previous(ActionExecuted, applied_events)
             else:
                 applied_events.append(event)
         return applied_events

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -250,16 +250,15 @@ def test_revert_user_utterance_event(default_domain):
     tracker.update(ActionExecuted("my_action_2"))
     tracker.update(ActionExecuted(ACTION_LISTEN_NAME))
 
-
-    print("USER - {}".format(list(tracker.generate_all_prior_states())))
-
-    # Expecting count of 6: 5 executed actions + 1 final state.
+    # Expecting count of 6:
+    #   +5 executed actions
+    #   +1 final state
     assert tracker.latest_action_name == ACTION_LISTEN_NAME
     assert len(list(tracker.generate_all_prior_states())) == 6
 
     tracker.update(UserUtteranceReverted())
 
-    # Expecting count of 6:
+    # Expecting count of 3:
     #   +5 executed actions
     #   +1 final state
     #   -2 rewound actions associated with the /goodbye


### PR DESCRIPTION
**Proposed changes**:
- When rewinding events due to a `UserUtteranceReverted` event, also rewind the previous action, which is by definition a listen

**Note:**
This seemed like the easy fix, but there may be a more elegant solution. Happy to look at alternate approaches.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [n/a] updated the documentation
- [x] updated the changelog
