### PR TITLE
Adds conflict detector for training data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 - Timestamp to every event
 - added a Slack channel that allows Rasa Core to communicate via a Slack app
 - added a Telegram channel that allows Rasa Core to communicate via a Telegram bot
+- added an argument to ``Agent.train()`` to detect conflicting training data
 
 Changed
 -------

--- a/docs/featurisation.rst
+++ b/docs/featurisation.rst
@@ -35,3 +35,10 @@ The parameter ``max_history`` defines how many states go into defining each row 
 
 Hence the statement above that ``X`` is 2D is actually false, it has shape ``(num_states, max_history, num_features)``.
 For most algorithms you want a flat feature vector, so you will have to reshape this to ``(num_states, max_history * num_features)``.
+
+Troubleshooting
+---------------
+
+Improperly configured stories may lead to identical featurizations having different labels applied to them, which will lower the accuracy of the machine learning algorithms.
+
+If you suspect that your data may be generating conflicting samples, you can pass the ``detect_conflicts=True`` argument to ``Agent.train()``, and it will emit warnings if conflicts are detected.

--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -143,13 +143,14 @@ class Agent(object):
                 p.toggle(activate)
 
     def train(self, filename=None, model_path=None, remove_duplicates=True,
-              **kwargs):
+              detect_conflicts=False, **kwargs):
         # type: (Optional[Text], Optional[Text], **Any) -> None
         """Train the policies / policy ensemble using dialogue data from file"""
 
         trainer = PolicyTrainer(self.policy_ensemble, self.domain,
                                 self.featurizer)
-        trainer.train(filename, remove_duplicates=remove_duplicates, **kwargs)
+        trainer.train(filename, remove_duplicates=remove_duplicates,
+                      detect_conflicts=detect_conflicts, **kwargs)
 
         if model_path:
             self.persist(model_path)

--- a/rasa_core/policies/trainer.py
+++ b/rasa_core/policies/trainer.py
@@ -22,7 +22,8 @@ class PolicyTrainer(object):
 
     def train(self, filename=None, max_history=3,
               augmentation_factor=20, max_training_samples=None,
-              max_number_of_trackers=2000, remove_duplicates=True, **kwargs):
+              max_number_of_trackers=2000, remove_duplicates=True,
+              detect_conflicts=False, **kwargs):
         """Trains a policy on a domain using training data from a file.
 
         :param augmentation_factor: how many stories should be created by
@@ -36,6 +37,7 @@ class PolicyTrainer(object):
                                        story file parsing - `None` for unlimited
         :param remove_duplicates: remove duplicates from the training set before
                                   training
+        :param detect_conflicts: detects conflicting labels in the training set
         :param kwargs: additional arguments passed to the underlying ML trainer
                        (e.g. keras parameters)
         :return: trained policy
@@ -48,14 +50,16 @@ class PolicyTrainer(object):
                                            augmentation_factor,
                                            max_training_samples,
                                            max_number_of_trackers,
-                                           remove_duplicates)
+                                           remove_duplicates,
+                                           detect_conflicts)
 
         self.ensemble.train(training_data, self.domain, self.featurizer, **kwargs)
 
     def _prepare_training_data(self, filename, max_history, augmentation_factor,
                                max_training_samples=None,
                                max_number_of_trackers=2000,
-                               remove_duplicates=True):
+                               remove_duplicates=True,
+                               detect_conflicts=False):
         """Reads training data from file and prepares it for the training."""
 
         from rasa_core.training import extract_training_data_from_file
@@ -69,7 +73,8 @@ class PolicyTrainer(object):
                     augmentation_factor=augmentation_factor,
                     max_history=max_history,
                     remove_duplicates=remove_duplicates,
-                    max_number_of_trackers=max_number_of_trackers)
+                    max_number_of_trackers=max_number_of_trackers,
+                    detect_conflicts=detect_conflicts)
             if max_training_samples is not None:
                 training_data.limit_training_data_to(max_training_samples)
             return training_data

--- a/rasa_core/training/__init__.py
+++ b/rasa_core/training/__init__.py
@@ -38,7 +38,8 @@ def extract_training_data_from_file(
         augmentation_factor=20,  # type: int
         max_history=1,  # type: int
         remove_duplicates=True,
-        max_number_of_trackers=2000  # type: int
+        max_number_of_trackers=2000,  # type: int
+        detect_conflicts=False  # type: bool
 ):
     # type: (...) -> DialogueTrainingData
 
@@ -47,7 +48,8 @@ def extract_training_data_from_file(
                                remove_duplicates,
                                augmentation_factor,
                                max_history,
-                               max_number_of_trackers)
+                               max_number_of_trackers,
+                               detect_conflicts=detect_conflicts)
     return g.generate()
 
 

--- a/rasa_core/training/generator.py
+++ b/rasa_core/training/generator.py
@@ -241,7 +241,6 @@ class TrainingsDataGenerator(object):
                     y_result.shape[0]))
 
         if self.config.detect_conflicts:
-            logger.info("Detecting conflicts")
             self._issue_conflicting_labels_notification(X_result, y_result)
 
         return DialogueTrainingData(X_result, y_result, metadata)

--- a/rasa_core/training/generator.py
+++ b/rasa_core/training/generator.py
@@ -245,7 +245,6 @@ class TrainingsDataGenerator(object):
 
         return DialogueTrainingData(X_result, y_result, metadata)
 
-
     def _phase_names(self):
         # type: () -> List[Text]
         """Create names for the different data generation phases"""


### PR DESCRIPTION
**Proposed changes**:
Adds an optional argument to `Agent.train()` which will emit warnings if the generated training data contains conflicting labels for the same feature vector.

This is probably not the most efficient way to go about it, so I left it off by default, but it can come in handy during those "why is my accuracy so low?" moments.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [n/a] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
