### PR TITLE
Restores a dumped tracker from a json file, replayes the conversation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 
 Added
 -----
+- script to reload a dumped trackers state and to continue the conversation
+  at the end of the stored dialogue
 
 Changed
 -------

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -1,0 +1,109 @@
+{
+  "latest_message": {
+    "entities": [],
+    "intent": {
+      "confidence": 0.60,
+      "name": "default"
+    },
+    "text": "I am very good",
+    "intent_ranking": [
+      {
+        "confidence": 0.60,
+        "name": "default"
+      },
+      {
+        "confidence": 0.20,
+        "name": "greet"
+      },
+      {
+        "confidence": 0.20,
+        "name": "goodbye"
+      }
+    ]
+  },
+  "sender_id": "mysender",
+  "paused": false,
+  "latest_event_time": 1517821726.211042,
+  "slots": {"name": null},
+  "events": [
+    {
+      "timestamp": 1517821726.211031,
+      "event": "action",
+      "name": "action_listen"
+    },
+    {
+      "timestamp": 1517821726.200036,
+      "parse_data": {
+        "entities": [],
+        "intent": {
+          "confidence": 0.54,
+          "name": "greet"
+        },
+        "text": "hello",
+        "intent_ranking": [
+          {
+            "confidence": 0.54,
+            "name": "greet"
+          },
+          {
+            "confidence": 0.31,
+            "name": "goodbye"
+          },
+          {
+            "confidence": 0.15,
+            "name": "default"
+          }
+        ]
+      },
+      "event": "user",
+      "text": "hello"
+    },
+    {
+      "timestamp": 1517821726.200373,
+      "event": "action",
+      "name": "utter_greet"
+    },
+    {
+      "timestamp": 1517821726.211038,
+      "event": "action",
+      "name": "action_listen"
+    },
+    {
+      "timestamp": 1517821726.209836,
+      "parse_data": {
+        "entities": [],
+        "intent": {
+          "confidence": 0.60,
+          "name": "default"
+        },
+        "text": "I am very good",
+        "intent_ranking": [
+          {
+            "confidence": 0.60,
+            "name": "default"
+          },
+          {
+            "confidence": 0.20,
+            "name": "greet"
+          },
+          {
+            "confidence": 0.20,
+            "name": "goodbye"
+          }
+        ]
+      },
+      "event": "user",
+      "text": "I am very good"
+    },
+    {
+      "timestamp": 1517821726.209908,
+      "event": "action",
+      "name": "utter_default"
+    },
+    {
+      "timestamp": 1517821726.211042,
+      "event": "action",
+      "name": "action_listen"
+    }
+  ]
+}

--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -26,8 +26,11 @@ class ConsoleOutputChannel(OutputChannel):
 class ConsoleInputChannel(InputChannel):
     """Input channel that reads the user messages from the command line."""
 
+    def __init__(self, sender_id=UserMessage.DEFAULT_SENDER_ID):
+        self.sender_id = sender_id
+
     def _record_messages(self, on_message, max_message_limit=None):
-        utils.print_color("Bot loaded. Type a message and press enter : ",
+        utils.print_color("Bot loaded. Type a message and press enter: ",
                           utils.bcolors.OKGREEN)
         num_messages = 0
         while max_message_limit is None or num_messages < max_message_limit:
@@ -36,10 +39,9 @@ class ConsoleInputChannel(InputChannel):
                 # in python 2 input doesn't return unicode values
                 text = text.decode("utf-8")
             if text == INTENT_MESSAGE_PREFIX + 'stop':
-                import os
-                # sys.exit(1)
-                os._exit(1)
-            on_message(UserMessage(text, ConsoleOutputChannel()))
+                return
+            on_message(UserMessage(text, ConsoleOutputChannel(),
+                                   self.sender_id))
             num_messages += 1
 
     def start_async_listening(self, message_queue):

--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -27,6 +27,7 @@ class ConsoleInputChannel(InputChannel):
     """Input channel that reads the user messages from the command line."""
 
     def __init__(self, sender_id=UserMessage.DEFAULT_SENDER_ID):
+        # type: (Text) -> None
         self.sender_id = sender_id
 
     def _record_messages(self, on_message, max_message_limit=None):

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -11,6 +11,7 @@ from difflib import SequenceMatcher
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 
+from rasa_core import utils
 from rasa_core.agent import Agent
 from rasa_core.events import ActionExecuted, UserUttered
 from rasa_core.interpreter import RegexInterpreter, RasaNLUInterpreter
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 def create_argument_parser():
     """Create argument parser for the evaluate script."""
+
     parser = argparse.ArgumentParser(
             description='evaluates a dialogue model')
     parser.add_argument(
@@ -50,23 +52,7 @@ def create_argument_parser():
             default="story_confmat.pdf",
             help="output path for the created evaluation plot")
 
-    # arguments for logging configuration
-    parser.add_argument(
-            '--debug',
-            help="Print lots of debugging statements. "
-                 "Sets logging level to DEBUG",
-            action="store_const",
-            dest="loglevel",
-            const=logging.DEBUG,
-            default=logging.WARNING,
-    )
-    parser.add_argument(
-            '-v', '--verbose',
-            help="Be verbose. Sets logging level to INFO",
-            action="store_const",
-            dest="loglevel",
-            const=logging.INFO,
-    )
+    utils.add_logging_option_arguments(parser)
     return parser
 
 

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -56,7 +56,7 @@ def create_argument_parser():
     return parser
 
 
-def _min_list_distance(pred, actual):
+def min_list_distance(pred, actual):
     """Calculate the distance between the two lists."""
     padded_pred = []
     padded_actual = []
@@ -72,19 +72,20 @@ def _min_list_distance(pred, actual):
     return padded_pred, padded_actual
 
 
+def actions_since_last_utterance(tracker):
+    actions = []
+    for e in reversed(tracker.events):
+        if isinstance(e, UserUttered):
+            break
+        elif isinstance(e, ActionExecuted):
+            actions.append(e.action_name)
+    actions.reverse()
+    return actions
+
+
 def collect_story_predictions(story_file, policy_model_path, nlu_model_path,
                               max_stories=None, shuffle_stories=True):
     """Test the stories from a file, running them through the stored model."""
-
-    def actions_since_last_utterance(tracker):
-        actions = []
-        for e in reversed(tracker.events):
-            if isinstance(e, UserUttered):
-                break
-            elif isinstance(e, ActionExecuted):
-                actions.append(e.action_name)
-        actions.reverse()
-        return actions
 
     if nlu_model_path is not None:
         interpreter = RasaNLUInterpreter(model_directory=nlu_model_path)
@@ -119,7 +120,7 @@ def collect_story_predictions(story_file, policy_model_path, nlu_model_path,
 
         for i, event in enumerate(events[1:]):
             if isinstance(event, UserUttered):
-                p, a = _min_list_distance(last_prediction,
+                p, a = min_list_distance(last_prediction,
                                           actions_between_utterances)
                 preds.extend(p)
                 actual.extend(a)

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -20,6 +20,19 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def deserialise_events(serialized_events, domain):
+    # Example format: {"event": "set_slot", "value": 5, "name": "my_slot"}
+
+    deserialized = []
+    for e in serialized_events:
+        etype = e.get("event")
+        if etype is not None:
+            copied = e.copy()
+            del copied["event"]
+            deserialized.append(Event.from_parameters(etype, copied, domain))
+    return deserialized
+
+
 # noinspection PyProtectedMember
 class Event(object):
     """An event is one of the following:

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -11,7 +11,9 @@ import time
 import jsonpickle
 import typing
 from builtins import str
+from typing import List, Dict, Text, Any
 
+import rasa_core
 from rasa_core import utils
 
 if typing.TYPE_CHECKING:
@@ -21,7 +23,12 @@ logger = logging.getLogger(__name__)
 
 
 def deserialise_events(serialized_events, domain):
-    # Example format: {"event": "set_slot", "value": 5, "name": "my_slot"}
+    # type: (List[Dict[Text, Any]], rasa_core.domain.Domain) -> List[Event]
+    """Convert a list of dictionaries to a list of corresponding events.
+
+    Example format:
+        [{"event": "set_slot", "value": 5, "name": "my_slot"}]
+    """
 
     deserialized = []
     for e in serialized_events:

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -37,6 +37,7 @@ class PolicyEnsemble(object):
             self.action_fingerprints = {}
 
     def max_history(self):
+        # type: () -> Optional[int]
         """Return max history, only works if the ensemble is already trained."""
 
         if self.policies:

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -36,6 +36,14 @@ class PolicyEnsemble(object):
         else:
             self.action_fingerprints = {}
 
+    def max_history(self):
+        """Return max history, only works if the ensemble is already trained."""
+
+        if self.policies:
+            return self.policies[0].max_history
+        else:
+            return None
+
     def train(self, training_data, domain, featurizer, **kwargs):
         # type: (DialogueTrainingData, Domain, Featurizer, **Any) -> None
         if not training_data.is_empty():
@@ -56,8 +64,9 @@ class PolicyEnsemble(object):
         predict the action. Returns the index of the next action"""
         probabilities = self.probabilities_using_best_policy(tracker, domain)
         max_index = np.argmax(probabilities)
-        logger.debug("Predicted next action #{} with prob {:.2f}.".format(
-                max_index, probabilities[max_index]))
+        logger.debug("Predicted next action '{}' with prob {:.2f}.".format(
+                domain.action_for_index(max_index).name(),
+                probabilities[max_index]))
         return max_index
 
     def probabilities_using_best_policy(self, tracker, domain):
@@ -103,10 +112,7 @@ class PolicyEnsemble(object):
         # type: (Text) -> None
         """Persists the policy to storage."""
 
-        if self.policies:
-            self._persist_metadata(path, self.policies[0].max_history)
-        else:
-            self._persist_metadata(path, None)
+        self._persist_metadata(path, self.max_history())
 
         for policy in self.policies:
             policy.persist(path)

--- a/rasa_core/restore.py
+++ b/rasa_core/restore.py
@@ -46,8 +46,7 @@ def create_argument_parser():
 
 def check_prediction_aligns_with_story(last_prediction,
                                        actions_between_utterances):
-    p, a = evaluate.min_list_distance(last_prediction,
-                                      actions_between_utterances)
+    p, a = evaluate.align_lists(last_prediction, actions_between_utterances)
     if p != a:
         logger.warn("Model predicted different actions than the "
                     "model used to create the story! Expected: "

--- a/rasa_core/restore.py
+++ b/rasa_core/restore.py
@@ -65,7 +65,7 @@ def _replay_events(tracker, agent):
     created by the agent are compared to the logged ones of the tracker that
     is getting replayed. If they differ, a warning is logged.
 
-    At the end, the tracker stored in the agents tracker store for the
+    At the end, the tracker stored in the agent's tracker store for the
     same sender id will have quite the same state as the one
     that got replayed."""
 

--- a/rasa_core/restore.py
+++ b/rasa_core/restore.py
@@ -8,6 +8,7 @@ import json
 import logging
 
 from builtins import str
+from typing import Text, Optional, List
 
 from rasa_core import utils, evaluate
 from rasa_core.actions.action import ActionListen
@@ -44,8 +45,11 @@ def create_argument_parser():
     return parser
 
 
-def check_prediction_aligns_with_story(last_prediction,
-                                       actions_between_utterances):
+def _check_prediction_aligns_with_story(last_prediction,
+                                        actions_between_utterances):
+    # type: (List[Text], List[Text]) -> None
+    """Emit a warning if predictions do not align with expected actions."""
+
     p, a = evaluate.align_lists(last_prediction, actions_between_utterances)
     if p != a:
         logger.warn("Model predicted different actions than the "
@@ -53,7 +57,53 @@ def check_prediction_aligns_with_story(last_prediction,
                     "{} but got {}.".format(p, a))
 
 
+def _replay_events(tracker, agent):
+    # type: (DialogueStateTracker, Agent) -> None
+    """Take a tracker and replay the logged user utterances against an agent.
+
+    During replaying of the user utterances, the executed actions and events
+    created by the agent are compared to the logged ones of the tracker that
+    is getting replayed. If they differ, a warning is logged.
+
+    At the end, the tracker stored in the agents tracker store for the
+    same sender id will have quite the same state as the one
+    that got replayed."""
+
+    actions_between_utterances = []
+    last_prediction = [ActionListen().name()]
+
+    for i, event in enumerate(tracker.events_after_latest_restart()):
+        if isinstance(event, UserUttered):
+            _check_prediction_aligns_with_story(last_prediction,
+                                                actions_between_utterances)
+
+            actions_between_utterances = []
+            print(utils.wrap_with_color(event.text, utils.bcolors.OKGREEN))
+            agent.handle_message(event.text, sender_id=tracker.sender_id,
+                                 output_channel=ConsoleOutputChannel())
+            tracker = agent.tracker_store.retrieve(tracker.sender_id)
+            last_prediction = evaluate.actions_since_last_utterance(tracker)
+
+        elif isinstance(event, ActionExecuted):
+            actions_between_utterances.append(event.action_name)
+
+    _check_prediction_aligns_with_story(last_prediction,
+                                        actions_between_utterances)
+
+
+def _load_tracker_from_json(tracker_dump, agent):
+    # type: (Text, Agent) -> DialogueStateTracker
+    """Read the json dump from the file and instantiate a tracker it."""
+
+    tracker_json = json.loads(utils.read_file(tracker_dump))
+    sender_id = tracker_json.get("sender_id", UserMessage.DEFAULT_SENDER_ID)
+    return DialogueStateTracker.from_dict(sender_id,
+                                          tracker_json.get("events", []),
+                                          agent.domain)
+
+
 def main(model_directory, nlu_model=None, tracker_dump=None):
+    # type: (Text, Optional[Text], Optional[Text]) -> Agent
     """Run the agent."""
 
     logger.info("Rasa process starting")
@@ -61,38 +111,14 @@ def main(model_directory, nlu_model=None, tracker_dump=None):
 
     logger.info("Finished loading agent. Loading stories now.")
 
-    tracker_json = json.loads(utils.read_file(tracker_dump))
-    sender_id = tracker_json.get("sender_id", UserMessage.DEFAULT_SENDER_ID)
-    tracker = DialogueStateTracker.from_dict(sender_id,
-                                             tracker_json.get("events", []),
-                                             agent.domain)
-
-    actions_between_utterances = []
-    last_prediction = [ActionListen().name()]
-
-    for i, event in enumerate(tracker.events_after_latest_restart()):
-        if isinstance(event, UserUttered):
-            check_prediction_aligns_with_story(last_prediction,
-                                               actions_between_utterances)
-
-            actions_between_utterances = []
-            print(utils.wrap_with_color(event.text, utils.bcolors.OKGREEN))
-            agent.handle_message(event.text, sender_id=sender_id,
-                                 output_channel=ConsoleOutputChannel())
-            tracker = agent.tracker_store.retrieve(sender_id)
-            last_prediction = evaluate.actions_since_last_utterance(tracker)
-
-        elif isinstance(event, ActionExecuted):
-            actions_between_utterances.append(event.action_name)
-
-    check_prediction_aligns_with_story(last_prediction,
-                                       actions_between_utterances)
+    tracker = _load_tracker_from_json(tracker_dump, agent)
+    _replay_events(tracker, agent)
 
     print(utils.wrap_with_color(
             "You can now continue the dialogue. "
             "Use '/stop' to exit the conversation.",
             utils.bcolors.OKGREEN + utils.bcolors.UNDERLINE))
-    agent.handle_channel(ConsoleInputChannel(sender_id))
+    agent.handle_channel(ConsoleInputChannel(tracker.sender_id))
 
     return agent
 

--- a/rasa_core/restore.py
+++ b/rasa_core/restore.py
@@ -1,0 +1,110 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import json
+import logging
+
+from builtins import str
+
+from rasa_core import utils, evaluate
+from rasa_core.actions.action import ActionListen
+from rasa_core.agent import Agent
+from rasa_core.channels import UserMessage
+from rasa_core.channels.console import ConsoleInputChannel, ConsoleOutputChannel
+from rasa_core.events import UserUttered, ActionExecuted
+from rasa_core.trackers import DialogueStateTracker
+
+logger = logging.getLogger()  # get the root logger
+
+
+def create_argument_parser():
+    """Parse all the command line arguments for the restore script."""
+
+    parser = argparse.ArgumentParser(
+            description='starts the bot')
+    parser.add_argument(
+            '-d', '--core',
+            required=True,
+            type=str,
+            help="core model to run")
+    parser.add_argument(
+            '-u', '--nlu',
+            type=str,
+            help="nlu model to run")
+    parser.add_argument(
+            'tracker_dump',
+            type=str,
+            help="file that contains a dumped tracker state in json format")
+
+    utils.add_logging_option_arguments(parser)
+
+    return parser
+
+
+def check_prediction_aligns_with_story(last_prediction,
+                                       actions_between_utterances):
+    p, a = evaluate.min_list_distance(last_prediction,
+                                      actions_between_utterances)
+    if p != a:
+        logger.warn("Model predicted different actions than the "
+                    "model used to create the story! Expected: "
+                    "{} but got {}.".format(p, a))
+
+
+def main(model_directory, nlu_model=None, tracker_dump=None):
+    """Run the agent."""
+
+    logger.info("Rasa process starting")
+    agent = Agent.load(model_directory, nlu_model)
+
+    logger.info("Finished loading agent. Loading stories now.")
+
+    tracker_json = json.loads(utils.read_file(tracker_dump))
+    sender_id = tracker_json.get("sender_id", UserMessage.DEFAULT_SENDER_ID)
+    tracker = DialogueStateTracker.from_dict(sender_id,
+                                             tracker_json.get("events", []),
+                                             agent.domain)
+
+    actions_between_utterances = []
+    last_prediction = [ActionListen().name()]
+
+    for i, event in enumerate(tracker.events_after_latest_restart()):
+        if isinstance(event, UserUttered):
+            check_prediction_aligns_with_story(last_prediction,
+                                               actions_between_utterances)
+
+            actions_between_utterances = []
+            print(utils.wrap_with_color(event.text, utils.bcolors.OKGREEN))
+            agent.handle_message(event.text, sender_id=sender_id,
+                                 output_channel=ConsoleOutputChannel())
+            tracker = agent.tracker_store.retrieve(sender_id)
+            last_prediction = evaluate.actions_since_last_utterance(tracker)
+
+        elif isinstance(event, ActionExecuted):
+            actions_between_utterances.append(event.action_name)
+
+    check_prediction_aligns_with_story(last_prediction,
+                                       actions_between_utterances)
+
+    print(utils.wrap_with_color(
+            "You can now continue the dialogue. "
+            "Use '/stop' to exit the conversation.",
+            utils.bcolors.OKGREEN + utils.bcolors.UNDERLINE))
+    agent.handle_channel(ConsoleInputChannel(sender_id))
+
+    return agent
+
+
+if __name__ == '__main__':
+    # Running as standalone python application
+    arg_parser = create_argument_parser()
+    cmdline_args = arg_parser.parse_args()
+
+    utils.configure_colored_logging(cmdline_args.loglevel)
+
+    main(cmdline_args.core,
+         cmdline_args.nlu,
+         cmdline_args.tracker_dump)

--- a/rasa_core/run.py
+++ b/rasa_core/run.py
@@ -55,24 +55,7 @@ def create_argument_parser():
         choices=["facebook", "slack", "telegram", "cmdline"],
         help="service to connect to")
 
-    # arguments for logging configuration
-    parser.add_argument(
-        '--debug',
-        help="Print lots of debugging statements. "
-             "Sets logging level to DEBUG",
-        action="store_const",
-        dest="loglevel",
-        const=logging.DEBUG,
-        default=logging.WARNING,
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        help="Be verbose. Sets logging level to INFO",
-        action="store_const",
-        dest="loglevel",
-        const=logging.INFO,
-    )
-
+    utils.add_logging_option_arguments(parser)
     return parser
 
 

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -11,10 +11,10 @@ from builtins import str
 from klein import Klein
 from typing import Union, Text, Optional
 
-from rasa_core import utils
+from rasa_core import utils, events
 from rasa_core.agent import Agent
-from rasa_core.events import Event
 from rasa_core.interpreter import NaturalLanguageInterpreter
+from rasa_core.trackers import DialogueStateTracker
 from rasa_core.version import __version__
 from rasa_nlu.server import check_cors, requires_auth
 
@@ -59,18 +59,6 @@ def create_argument_parser():
 
     utils.add_logging_option_arguments(parser)
     return parser
-
-
-def convert_obj_2_tracker_events(serialized_events, domain):
-    # Example format: {"event": "set_slot", "value": 5, "name": "my_slot"}
-
-    deserialized = []
-    for e in serialized_events:
-        etype = e.get("event")
-        if etype is not None:
-            del e["event"]
-            deserialized.append(Event.from_parameters(etype, e, domain))
-    return deserialized
 
 
 def _configure_logging(loglevel, logfile):
@@ -137,12 +125,11 @@ class RasaCoreServer(object):
                 request.content.read().decode('utf-8', 'strict'))
         encoded_events = request_params.get("events", [])
         executed_action = request_params.get("executed_action", None)
-        events = convert_obj_2_tracker_events(encoded_events,
-                                              self.agent.domain)
+        evts = events.deserialise_events(encoded_events, self.agent.domain)
         try:
             response = self.agent.continue_message_handling(sender_id,
                                                             executed_action,
-                                                            events)
+                                                            evts)
         except ValueError as e:
             request.setResponseCode(400)
             return json.dumps({"error": e.message})
@@ -161,10 +148,9 @@ class RasaCoreServer(object):
         request.setHeader('Content-Type', 'application/json')
         request_params = json.loads(
                 request.content.read().decode('utf-8', 'strict'))
-        events = convert_obj_2_tracker_events(request_params,
-                                              self.agent.domain)
+        evts = events.deserialise_events(request_params, self.agent.domain)
         tracker = self.agent.tracker_store.get_or_create_tracker(sender_id)
-        for e in events:
+        for e in evts:
             tracker.update(e)
         self.agent.tracker_store.save(tracker)
         return json.dumps(tracker.current_state())
@@ -188,12 +174,9 @@ class RasaCoreServer(object):
         request.setHeader('Content-Type', 'application/json')
         request_params = json.loads(
                 request.content.read().decode('utf-8', 'strict'))
-        events = convert_obj_2_tracker_events(request_params,
-                                              self.agent.domain)
-
-        tracker = self.agent.tracker_store.init_tracker(sender_id)
-        for e in events:
-            tracker.update(e)
+        tracker = DialogueStateTracker.from_dict(sender_id,
+                                                 request_params,
+                                                 self.agent.domain)
         self.agent.tracker_store.save(tracker)
 
         # will override an existing tracker with the same id!

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -11,6 +11,7 @@ from builtins import str
 from klein import Klein
 from typing import Union, Text, Optional
 
+from rasa_core import utils
 from rasa_core.agent import Agent
 from rasa_core.events import Event
 from rasa_core.interpreter import NaturalLanguageInterpreter
@@ -21,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 def create_argument_parser():
+    """Parse all the command line arguments for the server script."""
+
     parser = argparse.ArgumentParser(
             description='starts server to serve an agent')
     parser.add_argument(
@@ -54,23 +57,7 @@ def create_argument_parser():
             default="rasa_core.log",
             help="store log file in specified file")
 
-    # arguments for logging configuration
-    parser.add_argument(
-            '--debug',
-            help="Print lots of debugging statements. "
-                 "Sets logging level to DEBUG",
-            action="store_const",
-            dest="loglevel",
-            const=logging.DEBUG,
-            default=logging.WARNING,
-    )
-    parser.add_argument(
-            '-v', '--verbose',
-            help="Be verbose. Sets logging level to INFO",
-            action="store_const",
-            dest="loglevel",
-            const=logging.INFO,
-    )
+    utils.add_logging_option_arguments(parser)
     return parser
 
 

--- a/rasa_core/tracker_store.py
+++ b/rasa_core/tracker_store.py
@@ -27,9 +27,9 @@ class TrackerStore(object):
 
     def init_tracker(self, sender_id):
         return DialogueStateTracker(sender_id,
-                                       self.domain.slots,
-                                       self.domain.topics,
-                                       self.domain.default_topic)
+                                    self.domain.slots,
+                                    self.domain.topics,
+                                    self.domain.default_topic)
 
     def create_tracker(self, sender_id, append_action_listen=True):
         """Creates a new tracker for the sender_id.

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -14,6 +14,7 @@ from typing import Generator, Dict, Text, Any, Optional, Iterator
 from typing import List
 
 from rasa_core import utils
+from rasa_core import events
 from rasa_core.conversation import Dialogue, Topic
 from rasa_core.events import UserUttered, TopicSet, ActionExecuted, \
     Event, SlotSet, Restarted, ActionReverted, UserUtteranceReverted, BotUttered
@@ -26,6 +27,15 @@ if typing.TYPE_CHECKING:
 
 class DialogueStateTracker(object):
     """Maintains the state of a conversation."""
+
+    @classmethod
+    def from_dict(cls, sender_id, dump_as_dict, domain):
+        evts = events.deserialise_events(dump_as_dict, domain)
+        tracker = cls(sender_id, domain.slots, domain.topics,
+                      domain.default_topic)
+        for e in evts:
+            tracker.update(e)
+        return tracker
 
     def __init__(self, sender_id, slots,
                  topics=None,
@@ -74,9 +84,9 @@ class DialogueStateTracker(object):
         """Returns the current tracker state as an object."""
 
         if should_include_events:
-            events = [e.as_dict() for e in self.events]
+            evts = [e.as_dict() for e in self.events]
         else:
-            events = None
+            evts = None
 
         latest_event_time = None
         if len(self.events) > 0:
@@ -88,7 +98,7 @@ class DialogueStateTracker(object):
             "latest_message": self.latest_message.parse_data,
             "latest_event_time": latest_event_time,
             "paused": self.is_paused(),
-            "events": events
+            "events": evts
         }
 
     def current_slot_values(self):
@@ -197,7 +207,7 @@ class DialogueStateTracker(object):
         return applied_events
 
     def replay_events(self):
-        # type: (int) -> None
+        # type: () -> None
         """Update the tracker based on a list of events."""
 
         applied_events = self._applied_events()
@@ -283,12 +293,12 @@ class DialogueStateTracker(object):
                          "added all your slots to your domain file."
                          "".format(key))
 
-    def _create_events(self, events):
+    def _create_events(self, evts):
         # type: (List[Event]) -> deque
 
-        if events and not isinstance(events[0], Event):  # pragma: no cover
+        if evts and not isinstance(evts[0], Event):  # pragma: no cover
             raise ValueError("events, if given, must be a list of events")
-        return deque(events, self._max_event_history)
+        return deque(evts, self._max_event_history)
 
     def __eq__(self, other):
         if isinstance(other, type(self)):

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -17,6 +17,8 @@ from rasa_core.policies.memoization import MemoizationPolicy
 
 
 def create_argument_parser():
+    """Parse all the command line arguments for the training script."""
+
     parser = argparse.ArgumentParser(
             description='trains a dialogue model')
     parser.add_argument(
@@ -65,23 +67,7 @@ def create_argument_parser():
             default=50,
             help="how much data augmentation to use during training")
 
-    # arguments for logging configuration
-    parser.add_argument(
-            '--debug',
-            help="Print lots of debugging statements. "
-                 "Sets logging level to DEBUG",
-            action="store_const",
-            dest="loglevel",
-            const=logging.DEBUG,
-            default=logging.WARNING,
-    )
-    parser.add_argument(
-            '-v', '--verbose',
-            help="Be verbose. Sets logging level to INFO",
-            action="store_const",
-            dest="loglevel",
-            const=logging.INFO,
-    )
+    utils.add_logging_option_arguments(parser)
     return parser
 
 

--- a/rasa_core/utils.py
+++ b/rasa_core/utils.py
@@ -322,8 +322,13 @@ def fix_yaml_loader():
 
 def read_yaml_file(filename):
     fix_yaml_loader()
-    with io.open(filename, encoding="utf-8") as f:
-        return yaml.load(f.read())
+    return yaml.load(read_file(filename, "utf-8"))
+
+
+def read_file(filename, encoding="utf-8"):
+    """Read text from a file."""
+    with io.open(filename, encoding=encoding) as f:
+        return f.read()
 
 
 def is_training_data_empty(X):

--- a/rasa_core/utils.py
+++ b/rasa_core/utils.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import errno
 import json
+import logging
 import os, io
 from collections import deque
 from hashlib import sha1
@@ -15,6 +16,28 @@ import yaml
 from builtins import input, range, str
 from numpy import all, array
 from typing import Text, Any, List, Optional
+
+
+def add_logging_option_arguments(parser):
+    """Add options to an argument parser to configure logging levels."""
+
+    # arguments for logging configuration
+    parser.add_argument(
+            '--debug',
+            help="Print lots of debugging statements. "
+                 "Sets logging level to DEBUG",
+            action="store_const",
+            dest="loglevel",
+            const=logging.DEBUG,
+            default=logging.WARNING,
+    )
+    parser.add_argument(
+            '-v', '--verbose',
+            help="Be verbose. Sets logging level to INFO",
+            action="store_const",
+            dest="loglevel",
+            const=logging.INFO,
+    )
 
 
 def class_from_module_path(module_path):

--- a/rasa_core/visualize.py
+++ b/rasa_core/visualize.py
@@ -18,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 def create_argument_parser():
+    """Parse all the command line arguments for the visualisation script."""
+
     parser = argparse.ArgumentParser(
             description='Visualize the stories in a dialogue training file')
 
@@ -44,23 +46,7 @@ def create_argument_parser():
                         help="path of the Rasa NLU training data, "
                              "used to insert example messages into the graph")
 
-    # arguments for logging configuration
-    parser.add_argument(
-            '--debug',
-            help="Print lots of debugging statements. "
-                 "Sets logging level to DEBUG",
-            action="store_const",
-            dest="loglevel",
-            const=logging.DEBUG,
-            default=logging.INFO,
-    )
-    parser.add_argument(
-            '-v', '--verbose',
-            help="Be verbose. Sets logging level to INFO",
-            action="store_const",
-            dest="loglevel",
-            const=logging.INFO,
-    )
+    utils.add_logging_option_arguments(parser)
     return parser
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_requires = [
     "pytest-services",
     "pytest-cov",
     "pytest-xdist",
-    "pytest-twisted",
+    "pytest-twisted<1.6",
     "treq",
     "freezegun",
 ]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -48,3 +48,4 @@ def test_training_script(tmpdir):
                          use_online_learning=False,
                          nlu_model_path=None,
                          kwargs={})
+    assert True


### PR DESCRIPTION
**Proposed changes**:
- some formatting improvements
- added script to load a tracker that got dumped to a json file again and start a cmdline session (useful for wrong dialogue path debugging)
- will be undocumented and experimental for now - need to find out if this is a good way of debugging conversations.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
