### PR TITLE
Keep original stacktrace and error msg during failed story parsing

### DIFF
--- a/rasa_core/training/dsl.py
+++ b/rasa_core/training/dsl.py
@@ -141,10 +141,14 @@ class StoryFileReader(object):
                 lines = f.readlines()
             reader = StoryFileReader(domain, interpreter, template_variables)
             return reader.process_lines(lines)
-        except Exception:
-            logger.exception("Failed to parse '{}'".format(
-                    os.path.abspath(filename)))
-            raise ValueError("Invalid story file format.")
+        except ValueError as err:
+            file_info = ("Invalid story file format. Failed to parse "
+                         "'{}'".format(os.path.abspath(filename)))
+            logger.exception(file_info)
+            if not err.args:
+                err.args = ('',)
+            err.args = err.args + (file_info,)
+            raise
 
     @staticmethod
     def _parameters_from_json_string(s, line):
@@ -217,7 +221,7 @@ class StoryFileReader(object):
             except Exception as e:
                 msg = "Error in line {}: {}".format(line_num, e.message)
                 logger.error(msg, exc_info=1)
-                raise Exception(msg)
+                raise ValueError(msg)
         self._add_current_stories_to_result()
         return self.story_steps
 


### PR DESCRIPTION
**Proposed changes**:
- reraises initial exception and ammends the file information instead of raising a new exception - makes sure a user sees what the initial failure was.
- this is ugly - but there is no other way to support py2 and py3


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
