### PR TITLE
added warnings to cat slot and allow to pass val split to train

### DIFF
--- a/rasa_core/slots.py
+++ b/rasa_core/slots.py
@@ -188,6 +188,15 @@ class CategoricalSlot(Slot):
             for i, v in enumerate(self.values):
                 if v == str(self.value).lower():
                     r[i] = 1.0
+                    break
+            else:
+                logger.warn("Categorical slot '{}' is set to a value ('{}') "
+                            "that is not specified in the domain. "
+                            "Value will be ignored and the slot will "
+                            "behave as if it no value is set. "
+                            "Make sure to add all values a categorical "
+                            "slot should store to the domain."
+                            "".format(self.name, self.value))
         except (TypeError, ValueError):
             # probably hit something strange
             return r

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -52,6 +52,12 @@ def create_argument_parser():
             default=100,
             help="number of epochs to train the model")
     parser.add_argument(
+            '--validation_split',
+            type=float,
+            default=0.1,
+            help="Percentage of training samples used for validation, "
+                 "0.1 by default")
+    parser.add_argument(
             '--batch_size',
             type=int,
             default=20,
@@ -87,12 +93,11 @@ def train_dialogue_model(domain_file, stories_file, output_path,
         agent.train_online(
                 stories_file,
                 input_channel=ConsoleInputChannel(),
-                epochs=10,
-                model_path=output_path)
+                model_path=output_path,
+                **kwargs)
     else:
         agent.train(
                 stories_file,
-                validation_split=0.1,
                 **kwargs
         )
 
@@ -111,6 +116,7 @@ if __name__ == '__main__':
         "max_history": cmdline_args.history,
         "epochs": cmdline_args.epochs,
         "batch_size": cmdline_args.batch_size,
+        "validation_split": cmdline_args.validation_split,
         "augmentation_factor": cmdline_args.augmentation
     }
 


### PR DESCRIPTION
**Proposed changes**:
- added warning that gets raised if a categorical slot is set to a value it has not been configured to accept
- allow to pass in validation argument to train script

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the changelog
