### PR TITLE
webhook was not set previously

### DIFF
--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -105,7 +105,8 @@ class TelegramInput(HttpInputComponent):
                 return "Webhook setup successful"
             else:
                 return "Invalid webhook"
-
+        set_webhook()
+        
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])
         def message():
             if request.method == 'POST':

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -106,7 +106,6 @@ class TelegramInput(HttpInputComponent):
             else:
                 return "Invalid webhook"
         set_webhook()
-        
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])
         def message():
             if request.method == 'POST':

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -106,6 +106,7 @@ class TelegramInput(HttpInputComponent):
             else:
                 return "Invalid webhook"
         set_webhook()
+        
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])
         def message():
             if request.method == 'POST':

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -106,7 +106,7 @@ class TelegramInput(HttpInputComponent):
                 logger.info("Webhook Setup Successful")
             else:
                 return "Invalid webhook"
-                logger.info("Webhook Setup Failed")
+                logger.warn("Webhook Setup Failed")
         set_webhook()
         
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -103,8 +103,10 @@ class TelegramInput(HttpInputComponent):
             s = out_channel.setWebhook(self.webhook_url)
             if s:
                 return "Webhook setup successful"
+                logger.info("Webhook Setup Successful")
             else:
                 return "Invalid webhook"
+                logger.info("Webhook Setup Failed")
         set_webhook()
         
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])


### PR DESCRIPTION
telegram integration was not working prior because the webhook required for the integration was not set previously.

Now, the telegram integration is working correctly as expected

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
