### PR TITLE
Refactor telegram channel

### DIFF
--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -56,7 +56,9 @@ class TelegramOutput(Bot, OutputChannel):
                                                resize_keyboard=True,
                                                one_time_keyboard=True)
         else:
-            raise NotImplementedError
+            logger.error('Trying to send text with buttons for unknown button type {}'.format(button_type))
+            return
+
         return self.send_message(recipient_id, text, reply_markup=reply_markup)
 
 

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -40,20 +40,10 @@ class TelegramOutput(Bot, OutputChannel):
 
         :button_type custom: custom keyboard
         """
-        if button_type == "inline":
+        if button_type in ("inline", "vertical"):
             button_list = [[InlineKeyboardButton(s["title"],
                             callback_data=s["payload"]) for s in buttons]]
             reply_markup = InlineKeyboardMarkup(button_list)
-            return self.send_message(recipient_id, text,
-                                     reply_markup=reply_markup)
-        if button_type == "vertical":
-            button_list = []
-            for s in buttons:
-                button_list.append([InlineKeyboardButton(s["title"],
-                                    callback_data=s["payload"])])
-                reply_markup = InlineKeyboardMarkup(button_list)
-            return self.send_message(recipient_id, text,
-                                     reply_markup=reply_markup)
         elif button_type == "custom":
             button_list = []
             for bttn in buttons:
@@ -65,8 +55,9 @@ class TelegramOutput(Bot, OutputChannel):
             reply_markup = ReplyKeyboardMarkup(button_list,
                                                resize_keyboard=True,
                                                one_time_keyboard=True)
-            return self.send_message(recipient_id, text,
-                                     reply_markup=reply_markup)
+        else:
+            raise NotImplementedError
+        return self.send_message(recipient_id, text, reply_markup=reply_markup)
 
 
 class TelegramInput(HttpInputComponent):
@@ -102,11 +93,11 @@ class TelegramInput(HttpInputComponent):
         def set_webhook():
             s = out_channel.setWebhook(self.webhook_url)
             if s:
-                return "Webhook setup successful"
                 logger.info("Webhook Setup Successful")
+                return "Webhook setup successful"
             else:
+                logger.warning("Webhook Setup Failed")
                 return "Invalid webhook"
-                logger.warn("Webhook Setup Failed")
         set_webhook()
         
         @telegram_webhook.route("/webhook", methods=['GET', 'POST'])

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -40,10 +40,16 @@ class TelegramOutput(Bot, OutputChannel):
 
         :button_type custom: custom keyboard
         """
-        if button_type in ("inline", "vertical"):
+        if button_type == "inline":
             button_list = [[InlineKeyboardButton(s["title"],
                             callback_data=s["payload"]) for s in buttons]]
             reply_markup = InlineKeyboardMarkup(button_list)
+            
+        elif button_type == "vertical":
+            button_list = [[InlineKeyboardButton(s["title"],
+                            callback_data=s["payload"])] for s in buttons]
+            reply_markup = InlineKeyboardMarkup(button_list)
+            
         elif button_type == "custom":
             button_list = []
             for bttn in buttons:

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -56,7 +56,8 @@ class TelegramOutput(Bot, OutputChannel):
                                                resize_keyboard=True,
                                                one_time_keyboard=True)
         else:
-            logger.error('Trying to send text with buttons for unknown button type {}'.format(button_type))
+            logger.error('Trying to send text with buttons for unknown button type {}'
+                         ''.format(button_type))
             return
 
         return self.send_message(recipient_id, text, reply_markup=reply_markup)

--- a/rasa_core/channels/telegram.py
+++ b/rasa_core/channels/telegram.py
@@ -56,8 +56,8 @@ class TelegramOutput(Bot, OutputChannel):
                                                resize_keyboard=True,
                                                one_time_keyboard=True)
         else:
-            logger.error('Trying to send text with buttons for unknown button type {}'
-                         ''.format(button_type))
+            logger.error('Trying to send text with buttons for unknown '
+                         'button type {}'.format(button_type))
             return
 
         return self.send_message(recipient_id, text, reply_markup=reply_markup)


### PR DESCRIPTION
**Proposed changes**:
- I noticed there were two log messages enter after a return in TelegramInput.set_webhook that would never get executed. I also change logger.warn with logger.warning as the warn method is set for deprecation for a while.

After looking at the code I also saw some repeated code in TelegramOutput.send_text_with_buttons that could be simplified

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
