### PR TITLE
Have FormAction replace variables in utterance templates.

### DIFF
--- a/data/test_domains/query_form.yml
+++ b/data/test_domains/query_form.yml
@@ -1,0 +1,22 @@
+# all hashtags are comments :)
+action_factory: remote
+
+intents:
+ - inform
+
+slots:
+  username:
+    type: text
+  query:
+    type: text
+  requested_slot:
+    type: unfeaturized
+
+templates:
+  utter_ask_username:
+    - "what is your name?"
+  utter_ask_query:
+    - "hello {username}, what can I help you with?"
+
+actions:
+  - action_perform_query

--- a/rasa_core/actions/forms.py
+++ b/rasa_core/actions/forms.py
@@ -136,7 +136,9 @@ class FormAction(Action):
         for field in self.required_fields():
             if self.should_request_slot(temp_tracker, field.slot_name):
                 dispatcher.utter_template(
-                    "utter_ask_{}".format(field.slot_name))
+                    "utter_ask_{}".format(field.slot_name),
+                    filled_slots=temp_tracker.current_slot_values()
+                )
 
                 events.append(SlotSet("requested_slot", field.slot_name))
                 return events


### PR DESCRIPTION
**Proposed changes**:
- Have `FormAction` perform automatic slot filling on `utter_ask_` templates.

**Status (please check what you already did)**:
- [X] made PR ready for code review
- [X] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
