### PR TITLE
Gh477 fallback policy loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *#
 *.DS_Store
 *.egg
+*.eggs
 *.egg-info
 *.egg-info/
 *.iml
@@ -13,6 +14,7 @@
 *npy
 *pyc
 *~
+.env
 .cache/
 .coverage
 .idea/

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -63,6 +63,17 @@ class FallbackPolicy(Policy):
 
         pass
 
+    def should_fallback(self,
+                        nlu_confidence,  # type float
+                        last_action_name  # type: Text
+                        ):
+        # type: (...) -> bool
+        """It should predict fallback action only if
+        a. predicted NLU confidence is lower than ``nlu_threshold`` &&
+        b. last action is NOT fallback action
+        """
+        return nlu_confidence < self.nlu_threshold and last_action_name != self.fallback_action_name  # noqa
+
     def predict_action_probabilities(self, tracker, domain):
         # type: (DialogueStateTracker, Domain) -> List[float]
         """Predicts a fallback action if NLU confidence is low
@@ -77,7 +88,7 @@ class FallbackPolicy(Policy):
         # to not override standard behaviour
         nlu_confidence = nlu_data["intent"].get("confidence", 1.0)
 
-        if nlu_confidence < self.nlu_threshold:
+        if self.should_fallback(nlu_confidence, tracker.latest_action_name):
             logger.debug("NLU confidence {} is lower "
                          "than NLU threshold {}. "
                          "Predicting fallback action: {}"

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -72,7 +72,8 @@ class FallbackPolicy(Policy):
         a. predicted NLU confidence is lower than ``nlu_threshold`` &&
         b. last action is NOT fallback action
         """
-        return nlu_confidence < self.nlu_threshold and last_action_name != self.fallback_action_name  # noqa
+        return (nlu_confidence < self.nlu_threshold and
+                last_action_name != self.fallback_action_name)
 
     def predict_action_probabilities(self, tracker, domain):
         # type: (DialogueStateTracker, Domain) -> List[float]

--- a/rasa_core/policies/memoization.py
+++ b/rasa_core/policies/memoization.py
@@ -198,7 +198,11 @@ class MemoizationPolicy(Policy):
         if recalled is not None:
             logger.debug("Used memorised next action '{}'"
                          "".format(recalled))
-            result[recalled] = 1.0
+
+            # the memoization will use the confidence of NLU on the latest
+            # user message to set the confidence of the action
+            score = tracker.latest_message.intent.get("confidence", 1.0)
+            result[recalled] = score
 
         return result
 


### PR DESCRIPTION
**Proposed changes**:
- Fallback policy could trip cirucuit breaker if subsequent intent is
predicted lower than threshold thus added the condition to prevent
predict twice in a row.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
