### PR TITLE
fix make train-nlu

### DIFF
--- a/examples/moodbot/Makefile
+++ b/examples/moodbot/Makefile
@@ -8,7 +8,7 @@ help:
 
 train-nlu:
 	python -m rasa_nlu.train -c nlu_model_config.yml --fixed_model_name current \
-	       --data ./data/nlu.md --path models/nlu
+	       --data ./data/nlu.md --path models/ --project nlu
 
 train-core:
 	python -m rasa_core.train -s data/stories.md -d domain.yml -o models/dialogue --epochs 300


### PR DESCRIPTION
**Proposed changes**:
- the previous command was storing the model to `models/nlu/current/default` which doesn't correspond to the model path specified in any of the `make run`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
