### PR TITLE
Make dumping flattened stories optional

### DIFF
--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -323,13 +323,13 @@ class Agent(object):
                          "all old model files. Some files might be "
                          "overwritten.".format(model_path))
 
-    def persist(self, model_path):
+    def persist(self, model_path, dump_flattened_stories=False):
         # type: (Text) -> None
         """Persists this agent into a directory for later loading and usage."""
 
         self._clear_model_directory(model_path)
 
-        self.policy_ensemble.persist(model_path)
+        self.policy_ensemble.persist(model_path, dump_flattened_stories)
         self.domain.persist(os.path.join(model_path, "domain.yml"))
         self.domain.persist_specification(model_path)
 

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -119,7 +119,7 @@ class PolicyEnsemble(object):
             action_fingerprints[k] = {"slots": slots}
         return action_fingerprints
 
-    def _persist_metadata(self, path):
+    def _persist_metadata(self, path, dump_flattened_stories=False):
         # type: (Text) -> None
         """Persists the domain specification to storage."""
 
@@ -145,13 +145,17 @@ class PolicyEnsemble(object):
         }
 
         utils.dump_obj_as_json_to_file(domain_spec_path, metadata)
-        training.persist_data(self.training_trackers, training_data_path)
 
-    def persist(self, path):
+        # if there are lots of stories, saving flattened stories takes a long
+        # time, so this is turned off by default
+        if dump_flattened_stories:
+            training.persist_data(self.training_trackers, training_data_path)
+
+    def persist(self, path, dump_flattened_stories=False):
         # type: (Text) -> None
         """Persists the policy to storage."""
 
-        self._persist_metadata(path)
+        self._persist_metadata(path, dump_flattened_stories)
 
         for i, policy in enumerate(self.policies):
             dir_name = 'policy_{}_{}'.format(i, type(policy).__name__)

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -79,6 +79,11 @@ def create_argument_parser():
             help="If enabled, will create plots showing checkpoints "
                  "and their connections between story blocks in a  "
                  "file called `story_blocks_connections.pdf`.")
+    parser.add_argument(
+            '--dump_stories',
+            default=False,
+            action='store_true',
+            help="If enabled, save flattened stories to a file")
 
     utils.add_logging_option_arguments(parser)
     return parser
@@ -88,7 +93,8 @@ def train_dialogue_model(domain_file, stories_file, output_path,
                          use_online_learning=False,
                          nlu_model_path=None,
                          max_history=None,
-                         kwargs=None):
+                         kwargs=None,
+                         dump_flattened_stories=False):
     if not kwargs:
         kwargs = {}
 
@@ -117,7 +123,7 @@ def train_dialogue_model(domain_file, stories_file, output_path,
     else:
         agent.train(training_data, **kwargs)
 
-    agent.persist(output_path)
+    agent.persist(output_path, dump_flattened_stories)
 
 
 if __name__ == '__main__':
@@ -133,7 +139,8 @@ if __name__ == '__main__':
         "batch_size": cmdline_args.batch_size,
         "validation_split": cmdline_args.validation_split,
         "augmentation_factor": cmdline_args.augmentation,
-        "debug_plots": cmdline_args.debug_plots
+        "debug_plots": cmdline_args.debug_plots,
+        "dump_stories": cmdline_args.dump_stories
     }
 
     train_dialogue_model(cmdline_args.domain,

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -93,8 +93,8 @@ def train_dialogue_model(domain_file, stories_file, output_path,
                          use_online_learning=False,
                          nlu_model_path=None,
                          max_history=None,
-                         kwargs=None,
-                         dump_flattened_stories=False):
+                         dump_flattened_stories=False,
+                         kwargs=None):
     if not kwargs:
         kwargs = {}
 
@@ -139,8 +139,7 @@ if __name__ == '__main__':
         "batch_size": cmdline_args.batch_size,
         "validation_split": cmdline_args.validation_split,
         "augmentation_factor": cmdline_args.augmentation,
-        "debug_plots": cmdline_args.debug_plots,
-        "dump_stories": cmdline_args.dump_stories
+        "debug_plots": cmdline_args.debug_plots
     }
 
     train_dialogue_model(cmdline_args.domain,
@@ -149,4 +148,5 @@ if __name__ == '__main__':
                          cmdline_args.online,
                          cmdline_args.nlu,
                          cmdline_args.history,
+                         cmdline_args.dump_stories,
                          additional_arguments)


### PR DESCRIPTION
**Proposed changes**:
- fixes #529 
- when stories get longer, it takes ages to dump the flattened stories, so we'll make this optional

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
