### PR TITLE
wrap scheduler init in try/except

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 -------
 - changed the logic inside AugmentedMemoizationPolicy to recall actions only if they are the same in training stories
 - moved AugmentedMemoizationPolicy to memoization.py
+- wrapped initialization of BackgroundScheduler in try/except to allow running on jupyterhub / binderhub/ colaboratory
 
 Removed
 -------

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -9,6 +9,7 @@ import warnings
 from types import LambdaType
 
 from apscheduler.schedulers.background import BackgroundScheduler
+from pytz import UnknownTimeZoneError
 from typing import Optional, List, Dict, Any
 from typing import Text
 
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 try:
     scheduler = BackgroundScheduler()
     scheduler.start()
-except:
+except UnknownTimeZoneError:
     logger.warn("apscheduler failed to start. "
                 "This is probably because your system timezone is not set"
                 "Set it with e.g. echo \"Europe/Berlin\" > /etc/timezone")

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -29,11 +29,17 @@ from rasa_core.policies.ensemble import PolicyEnsemble
 from rasa_core.tracker_store import TrackerStore
 from rasa_core.trackers import DialogueStateTracker
 
-scheduler = BackgroundScheduler()
-scheduler.start()
+
 
 logger = logging.getLogger(__name__)
 
+try:
+    scheduler = BackgroundScheduler()
+    scheduler.start()
+except:
+    logger.warn("apscheduler failed to start. "
+                "This is probably because your system timezone is not set"
+                "Set it with e.g. echo \"Europe/Berlin\" > /etc/timezone")
 
 class MessageProcessor(object):
     def __init__(self,


### PR DESCRIPTION
**Proposed changes**:
- wrap initialisation of backgroundscheduler in a try/ excepy
- allows rasa core to run in docker containers without first setting the system timezone (e.g. binderhub, jupyterhub, colaboratory)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
