### PR TITLE
Allow unicode characters in extracted entity value

### DIFF
--- a/rasa_core/policies/online_trainer.py
+++ b/rasa_core/policies/online_trainer.py
@@ -249,7 +249,7 @@ class OnlinePolicyEnsemble(PolicyEnsemble):
                     latest_listen_flag = True
         slot_strs = []
         for k, s in tracker.slots.items():
-            colored_value = utils.wrap_with_color(str(s.value),
+            colored_value = utils.wrap_with_color(unicode(s.value),
                                                   utils.bcolors.WARNING)
             slot_strs.append("{}: {}".format(k, colored_value))
         print("we currently have slots: {}\n".format(", ".join(slot_strs)))


### PR DESCRIPTION
**Proposed changes**:
- change string parsing function from `str` to `unicode` to allow usage of unicode characters in extracted entity value during interactive training

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
