### PR TITLE
fixed event order for bot utterances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 - changed the logic inside AugmentedMemoizationPolicy to recall actions only if they are the same in training stories
 - moved AugmentedMemoizationPolicy to memoization.py
 - wrapped initialization of BackgroundScheduler in try/except to allow running on jupyterhub / binderhub/ colaboratory
+- fixed order of events logged on a tracker: action executed is now always
+  logged before bot utterances that action created
 
 Removed
 -------

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -31,7 +31,6 @@ from rasa_core.tracker_store import TrackerStore
 from rasa_core.trackers import DialogueStateTracker
 
 
-
 logger = logging.getLogger(__name__)
 
 try:
@@ -41,6 +40,7 @@ except UnknownTimeZoneError:
     logger.warn("apscheduler failed to start. "
                 "This is probably because your system timezone is not set"
                 "Set it with e.g. echo \"Europe/Berlin\" > /etc/timezone")
+
 
 class MessageProcessor(object):
     def __init__(self,
@@ -312,8 +312,9 @@ class MessageProcessor(object):
                          "code.".format(action.name()), )
             logger.error(e, exc_info=True)
             events = []
-        self.log_bot_utterances_on_tracker(tracker, dispatcher)
+
         self._log_action_on_tracker(tracker, action.name(), events)
+        self.log_bot_utterances_on_tracker(tracker, dispatcher)
         self._schedule_reminders(events, dispatcher)
 
         return self.should_predict_another_action(action.name(), events)

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -137,12 +137,24 @@ def test_tracker_state_regression_with_bot_utterance(default_agent):
         default_agent.handle_message("/greet", sender_id=sender_id)
     tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
 
-    expected = ["action_listen", "greet", None, "utter_greet",
+    expected = ["action_listen", "greet", "utter_greet", None,
                 "action_listen", "greet", "action_listen"]
-    print([e.as_story_string() for e in tracker.events])
-    for e in tracker.events:
-        print(e)
+
     assert [e.as_story_string() for e in tracker.events] == expected
+
+
+def test_bot_utterance_comes_after_action_event(default_agent):
+    sender_id = "test_bot_utterance_comes_after_action_event"
+
+    default_agent.handle_message("/greet", sender_id=sender_id)
+
+    tracker = default_agent.tracker_store.get_or_create_tracker(sender_id)
+
+    # important is, that the 'bot' comes after the second 'action' and not
+    # before
+    expected = ['action', 'user', 'action', 'bot', 'action']
+
+    assert [e.type_name for e in tracker.events] == expected
 
 
 def test_tracker_entity_retrieval(default_domain):


### PR DESCRIPTION
**Proposed changes**:
- fixed event order for bot utterances, executed actions are now always logged before any bot utterances are logged that that action created

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
