### PR TITLE
Fix removing generated OR checkpoint if it is the only one checkpoint

### DIFF
--- a/data/test_stories/stories.md
+++ b/data/test_stories/stories.md
@@ -1,5 +1,5 @@
 ## simple_story_without_checkpoint
-* simple                       <!-- user utterance in _intent[entities] format -->
+* simple
     - utter_default
     - utter_greet
 

--- a/data/test_stories/stories_checkpoint_after_or.md
+++ b/data/test_stories/stories_checkpoint_after_or.md
@@ -1,41 +1,9 @@
-## simple_story_without_checkpoint
-* simple                       <!-- user utterance in _intent[entities] format -->
-    - utter_default
-    - utter_greet
-
-## simple_story_with_only_start
-> check_greet                   <!-- checkpoints at the start define entry points -->
-* simple
-    - utter_default
-
-## simple_story_with_only_end
-* hello
-    - utter_greet
-    - slot{"name": "peter"}
-> check_greet                   <!-- checkpoint defining the end of this turn -->
-
-## simple_story_with_multiple_turns_or_only
+## story with checkpoint after or
 * affirm OR thank_you
 > check_after_or
 
-## simple_story_with_multiple_turns_after_or
+## story to continue checkpoint
 > check_after_or
     - utter_default
 * goodbye
     - utter_goodbye
-> check_goodbye        
-
-## why does the user want to leave?
-> check_goodbye
-* why
-    - utter_default
-> check_greet
-
-## show_it_all
-> check_greet
-> check_hello                   <!-- allows multiple entry points -->
-* next_intent
-    - utter_greet              <!-- actions taken by the bot -->
-> check_intermediate            <!-- allows intermediate checkpoints -->
-* change_bank_details
-    - utter_default            <!-- allows to end without checkpoints -->

--- a/data/test_stories/stories_checkpoint_after_or.md
+++ b/data/test_stories/stories_checkpoint_after_or.md
@@ -1,0 +1,41 @@
+## simple_story_without_checkpoint
+* simple                       <!-- user utterance in _intent[entities] format -->
+    - utter_default
+    - utter_greet
+
+## simple_story_with_only_start
+> check_greet                   <!-- checkpoints at the start define entry points -->
+* simple
+    - utter_default
+
+## simple_story_with_only_end
+* hello
+    - utter_greet
+    - slot{"name": "peter"}
+> check_greet                   <!-- checkpoint defining the end of this turn -->
+
+## simple_story_with_multiple_turns_or_only
+* affirm OR thank_you
+> check_after_or
+
+## simple_story_with_multiple_turns_after_or
+> check_after_or
+    - utter_default
+* goodbye
+    - utter_goodbye
+> check_goodbye        
+
+## why does the user want to leave?
+> check_goodbye
+* why
+    - utter_default
+> check_greet
+
+## show_it_all
+> check_greet
+> check_hello                   <!-- allows multiple entry points -->
+* next_intent
+    - utter_greet              <!-- actions taken by the bot -->
+> check_intermediate            <!-- allows intermediate checkpoints -->
+* change_bank_details
+    - utter_default            <!-- allows to end without checkpoints -->

--- a/rasa_core/training/structures.py
+++ b/rasa_core/training/structures.py
@@ -344,15 +344,15 @@ class StoryGraph(object):
             updated = step.create_copy(use_new_id=False)
             updated.start_checkpoints = self._checkpoint_difference(
                     updated.start_checkpoints, unused_overlapping_cps)
-            if step.start_checkpoints and not updated.start_checkpoints:
-                # remove story step if the generated checkpoints were unique
-                k_to_remove.add(k)
 
             # remove generated unused end checkpoints
             updated.end_checkpoints = self._checkpoint_difference(
                     updated.end_checkpoints, unused_genr_cps)
-            if step.end_checkpoints and not updated.end_checkpoints:
-                # remove story step if the generated checkpoints were unique
+
+            if (step.start_checkpoints and not updated.start_checkpoints or
+                    step.end_checkpoints and not updated.end_checkpoints):
+                # remove story step if the generated checkpoints
+                # were the only ones
                 k_to_remove.add(k)
 
             story_steps[k] = updated

--- a/rasa_core/training/structures.py
+++ b/rasa_core/training/structures.py
@@ -235,78 +235,76 @@ class StoryGraph(object):
         # type: () -> StoryGraph
         """Create a graph with the cyclic edges removed from this graph."""
 
-        if not self.cyclic_edge_ids:
-            return self
-
         story_end_checkpoints = self.story_end_checkpoints.copy()
         cyclic_edge_ids = self.cyclic_edge_ids
         # we need to remove the start steps and replace them with steps ending
         # in a special end checkpoint
         story_steps = {s.id: s for s in self.story_steps}
 
-        # we are going to do this in a recursive way. we are going to remove
-        # one cycle and then we are going to let the cycle detection run again
-        # this is not inherently necessary so if this becomes a performance
-        # issue, we can change it. It is actually enough to run the cycle
-        # detection only once and then remove one cycle after another, but
-        # since removing the cycle is done by adding / removing edges and nodes
-        # the logic is a lot easier if we only need to make sure the change is
-        # consistent if we only change one compared to changing all of them.
-
         # collect all overlapping checkpoints
         # we will remove unused start ones
         all_overlapping_cps = set()
 
-        for s, e in cyclic_edge_ids:
-            cid = utils.generate_id(max_chars=GENERATED_HASH_LENGTH)
-            prefix = GENERATED_CHECKPOINT_PREFIX + CHECKPOINT_CYCLE_PREFIX
-            # need abbreviations otherwise they are not visualized well
-            sink_cp_name = prefix + "SINK_" + cid
-            connector_cp_name = prefix + "CONN_" + cid
-            source_cp_name = prefix + "SRC_" + cid
-            story_end_checkpoints[sink_cp_name] = source_cp_name
+        if self.cyclic_edge_ids:
+            # we are going to do this in a recursive way. we are going to remove
+            # one cycle and then we are going to let the cycle detection run again
+            # this is not inherently necessary so if this becomes a performance
+            # issue, we can change it. It is actually enough to run the cycle
+            # detection only once and then remove one cycle after another, but
+            # since removing the cycle is done by adding / removing edges and nodes
+            # the logic is a lot easier if we only need to make sure the change is
+            # consistent if we only change one compared to changing all of them.
 
-            overlapping_cps = self.overlapping_checkpoint_names(
-                    story_steps[s].end_checkpoints,
-                    story_steps[e].start_checkpoints)
+            for s, e in cyclic_edge_ids:
+                cid = utils.generate_id(max_chars=GENERATED_HASH_LENGTH)
+                prefix = GENERATED_CHECKPOINT_PREFIX + CHECKPOINT_CYCLE_PREFIX
+                # need abbreviations otherwise they are not visualized well
+                sink_cp_name = prefix + "SINK_" + cid
+                connector_cp_name = prefix + "CONN_" + cid
+                source_cp_name = prefix + "SRC_" + cid
+                story_end_checkpoints[sink_cp_name] = source_cp_name
 
-            all_overlapping_cps.update(overlapping_cps)
+                overlapping_cps = self.overlapping_checkpoint_names(
+                        story_steps[s].end_checkpoints,
+                        story_steps[e].start_checkpoints)
 
-            # change end checkpoints of starts
-            start = story_steps[s].create_copy(use_new_id=False)
-            start.end_checkpoints = [cp
-                                     for cp in start.end_checkpoints
-                                     if cp.name not in overlapping_cps]
-            start.end_checkpoints.append(Checkpoint(sink_cp_name))
-            story_steps[s] = start
+                all_overlapping_cps.update(overlapping_cps)
 
-            needs_connector = False
+                # change end checkpoints of starts
+                start = story_steps[s].create_copy(use_new_id=False)
+                start.end_checkpoints = [cp
+                                         for cp in start.end_checkpoints
+                                         if cp.name not in overlapping_cps]
+                start.end_checkpoints.append(Checkpoint(sink_cp_name))
+                story_steps[s] = start
 
-            for k, step in list(story_steps.items()):
-                additional_ends = []
-                for original_cp in overlapping_cps:
-                    for cp in step.start_checkpoints:
-                        if cp.name == original_cp:
-                            if k == e:
-                                cp_name = source_cp_name
-                            else:
-                                cp_name = connector_cp_name
-                                needs_connector = True
+                needs_connector = False
 
-                            if not self._is_checkpoint_in_list(
-                                    cp_name, cp.conditions,
-                                    step.start_checkpoints):
-                                # add checkpoint only if it was not added
-                                additional_ends.append(
-                                        Checkpoint(cp_name, cp.conditions))
+                for k, step in list(story_steps.items()):
+                    additional_ends = []
+                    for original_cp in overlapping_cps:
+                        for cp in step.start_checkpoints:
+                            if cp.name == original_cp:
+                                if k == e:
+                                    cp_name = source_cp_name
+                                else:
+                                    cp_name = connector_cp_name
+                                    needs_connector = True
 
-                if additional_ends:
-                    updated = step.create_copy(use_new_id=False)
-                    updated.start_checkpoints.extend(additional_ends)
-                    story_steps[k] = updated
+                                if not self._is_checkpoint_in_list(
+                                        cp_name, cp.conditions,
+                                        step.start_checkpoints):
+                                    # add checkpoint only if it was not added
+                                    additional_ends.append(
+                                            Checkpoint(cp_name, cp.conditions))
 
-            if needs_connector:
-                start.end_checkpoints.append(Checkpoint(connector_cp_name))
+                    if additional_ends:
+                        updated = step.create_copy(use_new_id=False)
+                        updated.start_checkpoints.extend(additional_ends)
+                        story_steps[k] = updated
+
+                if needs_connector:
+                    start.end_checkpoints.append(Checkpoint(connector_cp_name))
 
         # the process above may generate unused checkpoints
         # we need to find them and remove them
@@ -340,17 +338,28 @@ class StoryGraph(object):
                            for cp_name in unused_cps
                            if cp_name.startswith(GENERATED_CHECKPOINT_PREFIX)}
 
+        k_to_remove = set()
         for k, step in story_steps.items():
             # changed all ends
             updated = step.create_copy(use_new_id=False)
             updated.start_checkpoints = self._checkpoint_difference(
                     updated.start_checkpoints, unused_overlapping_cps)
+            if step.start_checkpoints and not updated.start_checkpoints:
+                # remove story step if the generated checkpoints were unique
+                k_to_remove.add(k)
 
             # remove generated unused end checkpoints
             updated.end_checkpoints = self._checkpoint_difference(
                     updated.end_checkpoints, unused_genr_cps)
+            if step.end_checkpoints and not updated.end_checkpoints:
+                # remove story step if the generated checkpoints were unique
+                k_to_remove.add(k)
 
             story_steps[k] = updated
+
+        # remove unwanted story steps
+        for k in k_to_remove:
+            del story_steps[k]
 
     @staticmethod
     def _is_checkpoint_in_list(checkpoint_name, conditions, cps):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -53,24 +53,8 @@ def test_can_read_test_story_with_checkpoint_after_or(default_domain):
             tracker_limit=1000,
             remove_duplicates=False
     )
-    # the result should be identical as in the test above
-    assert len(trackers) == 7
-    # this should be the story simple_story_with_only_end -> show_it_all
-    # the generated stories are in a non stable order - therefore we need to
-    # do some trickery to find the one we want to test
-    tracker = [t for t in trackers if len(t.events) == 5][0]
-    assert tracker.events[0] == ActionExecuted("action_listen")
-    assert tracker.events[1] == UserUttered(
-            "simple",
-            intent={"name": "simple", "confidence": 1.0},
-            parse_data={'text': 'simple',
-                        'intent_ranking': [{'confidence': 1.0,
-                                            'name': 'simple'}],
-                        'intent': {'confidence': 1.0, 'name': 'simple'},
-                        'entities': []})
-    assert tracker.events[2] == ActionExecuted("utter_default")
-    assert tracker.events[3] == ActionExecuted("utter_greet")
-    assert tracker.events[4] == ActionExecuted("action_listen")
+    # there should be only 2 trackers
+    assert len(trackers) == 2
 
 
 def test_persist_and_read_test_story_graph(tmpdir, default_domain):

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -45,6 +45,34 @@ def test_can_read_test_story(default_domain):
     assert tracker.events[4] == ActionExecuted("action_listen")
 
 
+def test_can_read_test_story_with_checkpoint_after_or(default_domain):
+    trackers = training.load_data(
+            "data/test_stories/stories_checkpoint_after_or.md",
+            default_domain,
+            use_story_concatenation=False,
+            tracker_limit=1000,
+            remove_duplicates=False
+    )
+    # the result should be identical as in the test above
+    assert len(trackers) == 7
+    # this should be the story simple_story_with_only_end -> show_it_all
+    # the generated stories are in a non stable order - therefore we need to
+    # do some trickery to find the one we want to test
+    tracker = [t for t in trackers if len(t.events) == 5][0]
+    assert tracker.events[0] == ActionExecuted("action_listen")
+    assert tracker.events[1] == UserUttered(
+            "simple",
+            intent={"name": "simple", "confidence": 1.0},
+            parse_data={'text': 'simple',
+                        'intent_ranking': [{'confidence': 1.0,
+                                            'name': 'simple'}],
+                        'intent': {'confidence': 1.0, 'name': 'simple'},
+                        'entities': []})
+    assert tracker.events[2] == ActionExecuted("utter_default")
+    assert tracker.events[3] == ActionExecuted("utter_greet")
+    assert tracker.events[4] == ActionExecuted("action_listen")
+
+
 def test_persist_and_read_test_story_graph(tmpdir, default_domain):
     graph = training.extract_story_graph("data/test_stories/stories.md",
                                          default_domain)


### PR DESCRIPTION
**Proposed changes**:
- remove redundant generated `OR` checkpoints even if there are no cycles in the stories
- remove the whole story step if such redundant generated `OR` checkpoints were the only checkpoints

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog