### PR TITLE
Reduced Docker image size: removed pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ WORKDIR /app
 # Copy as early as possible so we can cache ...
 ADD requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 ADD . .
 
-RUN pip install -e .
+RUN pip install -e . --no-cache-dir
 
 VOLUME ["/app/dialogue", "/app/nlu", "/app/out"]
 


### PR DESCRIPTION
**Proposed changes**:
- Use `--no-cache-dir` in `pip install` to reduce image size
Managed to reduce more than 100Mb in local tests

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
