### PR TITLE
Consider text/image combinations in utter_response

### DIFF
--- a/rasa_core/dispatcher.py
+++ b/rasa_core/dispatcher.py
@@ -64,7 +64,7 @@ class Dispatcher(object):
             self.utter_button_message(message.get("text"),
                                       message.get("buttons"))
         # Sends a text message
-        else:
+        elif message.get("text"):
             self.utter_message(message.get("text"))
 
         # if there is an image we handle it separately as an attachment

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -48,6 +48,30 @@ def test_dispatcher_template_invalid_vars():
             "a template referencing an invalid {variable}.")
 
 
+def test_dispatcher_utter_response(default_dispatcher_collecting):
+    text_only_message = {"text": "hey"}
+    image_only_message = {"image": "https://i.imgur.com/nGF1K8f.jpg"}
+    text_and_image_message = {
+        "text": "look at this",
+        "image": "https://i.imgur.com/T5xVo.jpg"
+    }
+
+    default_dispatcher_collecting.utter_response(text_only_message)
+    default_dispatcher_collecting.utter_response(image_only_message)
+    default_dispatcher_collecting.utter_response(text_and_image_message)
+    collected = default_dispatcher_collecting.output_channel.messages
+
+    assert len(collected) == 4
+    assert collected[0] == {"recipient_id": "my-sender", "text": "hey"}
+    assert collected[1] == {
+        "recipient_id": "my-sender",
+        "text": "Image: https://i.imgur.com/nGF1K8f.jpg"}
+    assert collected[2] == {"recipient_id": "my-sender", "text": "look at this"}
+    assert collected[3] == {
+        "recipient_id": "my-sender",
+        "text": "Image: https://i.imgur.com/T5xVo.jpg"}
+
+
 def test_dispatcher_utter_buttons(default_dispatcher_collecting):
     buttons = [
         Button(title="Btn1", payload="/btn1"),


### PR DESCRIPTION
**Proposed changes**:
- Enables passing a dict like `{'image': image_url}` to `utter_response`
- Enables passing a dict with image and text `{'image': image_url, 'text': title}` to `utter_response`

Solves #813 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
