### PR TITLE
fix train script to read in fallback args

### DIFF
--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -188,7 +188,10 @@ if __name__ == '__main__':
         "batch_size": cmdline_args.batch_size,
         "validation_split": cmdline_args.validation_split,
         "augmentation_factor": cmdline_args.augmentation,
-        "debug_plots": cmdline_args.debug_plots
+        "debug_plots": cmdline_args.debug_plots,
+        "nlu_threshold": cmdline_args.nlu_threshold,
+        "core_threshold": cmdline_args.core_threshold,
+        "fallback_action_name": cmdline_args.fallback_action_name
     }
 
     if cmdline_args.url:


### PR DESCRIPTION
**Proposed changes**:
- The train script wasn't reading in the fallback policy related cmdline args, this fixes it

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
