### PR TITLE
Allowing default record expiration in the `RedisTrackerStore`

### DIFF
--- a/rasa_core/tracker_store.py
+++ b/rasa_core/tracker_store.py
@@ -119,16 +119,21 @@ class RedisTrackerStore(TrackerStore):
         pass
 
     def __init__(self, domain, host='localhost',
-                 port=6379, db=0, password=None, event_broker=None):
+                 port=6379, db=0, password=None, event_broker=None,
+                 record_exp=None):
 
         import redis
         self.red = redis.StrictRedis(host=host, port=port, db=db,
                                      password=password)
+        self.record_exp = record_exp
         super(RedisTrackerStore, self).__init__(domain, event_broker)
 
     def save(self, tracker, timeout=None):
         if self.event_broker:
             self.stream_events(tracker)
+
+        if not timeout and self.record_exp:
+            timeout = self.record_exp
 
         serialised_tracker = self.serialise_tracker(tracker)
         self.red.set(tracker.sender_id, serialised_tracker, ex=timeout)


### PR DESCRIPTION
A new argument (`record_exp`) of the `RedisTrackerStore` has been added to allow setting a default expiration (timeout) for all Redis records generated.

**Proposed changes**:
- Adding a default parameter for the `RedisTrackerStore` to allow the expiration of all created Redis records.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog

I have checked and currently no tests or documentations for the inner workings of the `RedisTrackerStore` and it seems this small changes are usually not listed in the changelog.