### PR TITLE
Improved event docs and removed outdated server docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,9 +16,12 @@ Added
 
 Changed
 -------
+- improved documentation for events (e.g. including json serialisation)
 
 Removed
 -------
+- outdated documentation for removed endpoints in the server
+  (``/parse`` & ``/continue``)
 
 Fixed
 -------

--- a/docs/api/events.rst
+++ b/docs/api/events.rst
@@ -4,131 +4,269 @@ Events
 ======
 List of all the events the dialogue system is able to handle and supports.
 
-An event can be referenced by its ``type_name`` attribute (e.g. when returning
-events in an http callback).
+Most of the time, you will set or receive events in their json
+representation. E.g. if you are modifying a conversation over the
+HTTP API, or if you are implementing your own action server.
 
 .. contents::
 
+General purpose events
+----------------------
 
-The Event base class
---------------------
-
-.. autoclass:: rasa_core.events.Event
-
-
-Events for Actions to Return
-----------------------------
+Event Base Class
+~~~~~~~~~~~~~~~~
 
 
-SlotSet
-^^^^^^^
+:Short: Base class for all of Rasa Core's events. **Can not directly be used!**
+:Description:
+    Contains common functionality for all events. E.g. it ensures, that
+    every event has a timestamp and a ``event`` attribute that describes
+    the type of the event (e.g. ``slot`` for the slot setting event).
+:Class:
+    .. autoclass:: rasa_core.events.Event
 
-.. autoclass:: rasa_core.events.SlotSet
+Set a Slot
+~~~~~~~~~~
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: SlotSet.apply_to
+:Short: Event to set a slot on a tracker
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER SetSlot
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.SlotSet
 
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
 
-Restarted
-^^^^^^^^^
-
-.. autoclass:: rasa_core.events.Restarted
-
-
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: Restarted.apply_to
-
-
-
-AllSlotsReset
-^^^^^^^^^^^^^
-
-.. autoclass:: rasa_core.events.AllSlotsReset
-
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: AllSlotsReset.apply_to
-
-
-ReminderScheduled
-^^^^^^^^^^^^^^^^^
-
-.. autoclass:: rasa_core.events.ReminderScheduled
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: SlotSet.apply_to
 
 
-ConversationPaused
-^^^^^^^^^^^^^^^^^^
+Restart a conversation
+~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: rasa_core.events.ConversationPaused
+:Short: Resets anything logged on the tracker.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER Restarted
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.Restarted
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: ConversationPaused.apply_to
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: Restarted.apply_to
 
 
-ConversationResumed
-^^^^^^^^^^^^^^^^^^^
+Reset all Slots
+~~~~~~~~~~~~~~~
 
-.. autoclass:: rasa_core.events.ConversationResumed
+:Short: Resets all the slots of a conversation.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER AllSlotsReset
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.AllSlotsReset
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: ConversationResumed.apply_to
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: AllSlotsReset.apply_to
 
 
-FollowupAction
-^^^^^^^^^^^^^^
+Schedule a reminder
+~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: rasa_core.events.FollowupAction
+:Short: Schedule an action to be executed in the future.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER ReminderScheduled
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.ReminderScheduled
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: FollowupAction.apply_to
+:Effect:
+    When added to a tracker, core will schedule the action to be
+    run in the future.
+
+Pause a conversation
+~~~~~~~~~~~~~~~~~~~~
+
+:Short: Stops the bot from responding to messages. Action prediction
+        will be halted until resumed.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER ConversationPaused
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.ConversationPaused
+
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: ConversationPaused.apply_to
+
+
+Resume a conversation
+~~~~~~~~~~~~~~~~~~~~~
+
+:Short: Resumes a previously paused conversation. The bot will start
+        predicting actions again.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER ConversationResumed
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.ConversationResumed
+
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: ConversationResumed.apply_to
+
+
+Force a followup action
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Short: Instead of predicting the next action, force the next action
+        to be a fixed one.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER FollowupAction
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.FollowupAction
+
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: FollowupAction.apply_to
 
 
 Automatically tracked events
 ----------------------------
 
-UserUttered
-^^^^^^^^^^^
 
-.. autoclass:: rasa_core.events.UserUttered
+User sent message
+~~~~~~~~~~~~~~~~~
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: UserUttered.apply_to
+:Short: Message a user sent to the bot.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER UserUttered
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.UserUttered
 
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
 
-BotUttered
-^^^^^^^^^^
-
-.. autoclass:: rasa_core.events.BotUttered
-
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: BotUttered.apply_to
-
-
-
-UserutteranceReverted
-^^^^^^^^^^^^^^^^^^^^^
-
-.. autoclass:: rasa_core.events.UserUtteranceReverted
-
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: UserUtteranceReverted.apply_to
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: UserUttered.apply_to
 
 
+Bot responded message
+~~~~~~~~~~~~~~~~~~~~~
 
-ActionReverted
-^^^^^^^^^^^^^^
+:Short: Message a bot sent to the user.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER BotUttered
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.BotUttered
 
-.. autoclass:: rasa_core.events.ActionReverted
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: ActionReverted.apply_to
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: BotUttered.apply_to
 
 
+Undo a user message
+~~~~~~~~~~~~~~~~~~~
 
-ActionExecuted
-^^^^^^^^^^^^^^
+:Short: Undoes all side effects that happened after the last user message
+        (including the ``user`` event of the message).
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER UserUtteranceReverted
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.UserUtteranceReverted
 
-.. autoclass:: rasa_core.events.ActionExecuted
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
 
-.. literalinclude:: ../../rasa_core/events/__init__.py
-   :pyobject: ActionExecuted.apply_to
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: UserUtteranceReverted.apply_to
 
+
+Undo an action
+~~~~~~~~~~~~~~
+
+:Short: Undoes all side effects that happened after the last action
+        (including the ``action`` event of the action).
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER ActionReverted
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.ActionReverted
+
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: ActionReverted.apply_to
+
+
+Log an executed action
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Short: Logs an action the bot executed to the conversation. Events that
+        action created are logged separately.
+:JSON:
+    .. literalinclude:: ../../tests/test_events.py
+      :lines: 2-
+      :dedent: 8
+      :start-after: # DOCS MARKER ActionExecuted
+      :end-before: # DOCS END
+:Class:
+    .. autoclass:: rasa_core.events.ActionExecuted
+
+:Effect:
+    When added to a tracker, this is the code used to update the tracker:
+
+    .. literalinclude:: ../../rasa_core/events/__init__.py
+      :pyobject: ActionExecuted.apply_to

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -39,6 +39,16 @@ General
 - utter templates that should be used as actions, now need to start with
   ``utter_``, otherwise the bot won't be able to find the action
 
+HTTP Server endpoints
+~~~~~~~~~~~~~~~~~~~~~
+- We removed ``/parse`` and ``/continue`` endpoints used for running actions
+  remotely. This has been replaced by the action server that allows you
+  to run your action code in any language. There are no replacement endpoints
+  for these two, as the flow of information has been changed: Instead of you
+  calling Rasa Core to update the tracker and receive the next action to be
+  executed, Rasa Core will call your action server once it predicted an action.
+  More information can be found in the updated docs for :ref:`customactions`.
+
 
 Webhooks
 ~~~~~~~~

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -91,80 +91,6 @@ An example request Rasa Core might make to your model server looks like this:
 
       $ curl --header "If-None-Match: d41d8cd98f00b204e9800998ecf8427e" http://my-server.com/models/default_core@latest
 
-.. _http_start_conversation:
-
-Starting a conversation
------------------------
-You need to do a ``POST`` to the ``/conversation/<sender_id>/parse`` endpoint.
-``<sender_id>`` is the conversation id (e.g. ``default`` if you just have one
-user, or the facebook user id or any other identifier):
-
-.. code-block:: bash
-
-    $ curl -XPOST localhost:5005/conversations/default/parse -d '{"query":"hello there"}'
-
-The server will respond with the next action you should take:
-
-.. code-block:: javascript
-
-    {
-      "next_action": "utter_ask_howcanhelp",
-      "tracker": {
-        "slots": {
-          "info": null,
-          "cuisine": null,
-          "people": null,
-          "matches": null,
-          "price": null,
-          "location": null
-        },
-        "sender_id": "default",
-        "latest_message": {
-          ...
-        }
-      }
-    }
-
-You now need to execute the action ``utter_ask_howcanhelp`` on your end. This
-might include sending a message to the output channel (e.g. back to facebook).
-
-After you finished running the mentioned action, you need to notify Rasa Core
-about that:
-
-.. code-block:: bash
-
-    $ curl -XPOST http://localhost:5005/conversations/default/continue -d \
-        '{"executed_action": "utter_ask_howcanhelp", "events": []}'
-
-Here the API should respond with:
-
-.. code-block:: javascript
-
-    {
-      "next_action":"action_listen",
-      "tracker": {
-        "slots": {
-          "info": null,
-          "cuisine": null,
-          "people": null,
-          "matches": null,
-          "price": null,
-          "location": null
-        },
-        "sender_id": "default",
-        "latest_message": {
-          ...
-        }
-      }
-    }
-
-This response tells you to wait for the next user message. You should not call
-the continue endpoint after you received a response containing ``action_listen``
-as the next action. Instead, wait for the next user message and call
-``/conversations/default/parse`` again followed by subsequent
-calls to ``/conversations/default/continue`` until you get ``action_listen``
-again.
-
 Events
 ------
 Events allow you to modify the internal state of the dialogue. This information
@@ -175,36 +101,13 @@ You can return multiple events as part of your query, e.g.:
 
 .. code-block:: bash
 
-    $ curl -XPOST http://localhost:5005/conversations/default/continue -d \
-        '{"executed_action": "search_restaurants", "events": [{"event": "slot", "name": "cuisine", "value": "mexican"}, {"event": "slot", "name": "people", "value": 5}]}'
+    $ curl -XPOST http://localhost:5005/conversations/default/tracker/events -d \
+        '{"event": "slot", "name": "cuisine", "value": "mexican"}'
 
-Here is a list of all available events you can append to the ``events`` array in
-your call to ``/conversation/<sender_id>/continue``.
 
-Set a slot
-::::::::::
-
-:name: ``slot``
-:Examples: ``"events": [{"event": "slot", "name": "cuisine", "value": "mexican"}]``
-:Description:
-    Will set the value of the slot to the passed one. The value you set should
-    be reasonable given the :ref:`slots type <slot_types>`.
-
-Restart
-:::::::
-
-:name: ``restart``
-:Examples: ``"events": [{"event": "restart"}]``
-:Description:
-    Restarts the conversation and resets all slots and past actions.
-
-Reset Slots
-:::::::::::
-
-:name: ``reset_slots``
-:Examples: ``"events": [{"event": "reset_slots"}]``
-:Description:
-    Resets all slots to their initial value.
+You can find a list of all events and their json representation
+at :ref:`events`. You need to send these json formats to the endpoint to
+log the event.
 
 
 Security Considerations
@@ -231,97 +134,11 @@ as a parameter:
 
 .. code-block:: bash
 
-    $ curl -XPOST localhost:5005/conversations/default/parse?token=thisismysecret -d '{"query":"hello there"}'
+    $ curl -XGET localhost:5005/conversations/default/tracker?token=thisismysecret
 
 
 Endpoints
 ---------
-
-.. http:post:: /conversations/(str:sender_id)/parse
-   :synopsis: Returns posts by the specified tag for the user
-
-   Notify the dialogue engine that the user posted a new message. You must
-   ``POST`` data in this format ``'{"query":"<your text to parse>"}'``,
-   you can do this with
-
-   **Example request**:
-
-   .. sourcecode:: bash
-
-      curl -XPOST localhost:5005/conversations/default/parse -d \
-        '{"query":"hello there"}' | python -mjson.tool
-
-   **Example response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Vary: Accept
-      Content-Type: text/javascript
-
-      {
-          "next_action": "utter_ask_howcanhelp",
-          "tracker": {
-              "latest_message": {
-                  ...
-              },
-              "sender_id": "default",
-              "slots": {
-                  "cuisine": null,
-                  "info": null,
-                  "location": null,
-                  "matches": null,
-                  "people": null,
-                  "price": null
-              }
-          }
-      }
-
-   :statuscode 200: no error
-
-
-.. http:post:: /conversations/(str:sender_id)/continue
-
-   Continue the prediction loop for the conversation with id `user_id`. Should
-   be called until the endpoint returns ``action_listen`` as the next action.
-   Between the calls to this endpoint, your code should execute the mentioned
-   next action. If you receive ``action_listen`` as the next action, you should
-   wait for the next user input.
-
-   **Example request**:
-
-   .. sourcecode:: bash
-
-      curl -XPOST http://localhost:5005/conversations/default/continue -d \
-        '{"executed_action": "utter_ask_howcanhelp", "events": []}' | python -mjson.tool
-
-   **Example response**:
-
-   .. sourcecode:: http
-
-      HTTP/1.1 200 OK
-      Vary: Accept
-      Content-Type: text/javascript
-
-      {
-          "next_action": "utter_ask_cuisine",
-          "tracker": {
-              "latest_message": {
-                  ...
-              },
-              "sender_id": "default",
-              "slots": {
-                  "cuisine": null,
-                  "info": null,
-                  "location": null,
-                  "matches": null,
-                  "people": null,
-                  "price": null
-              }
-          }
-      }
-
-   :statuscode 200: no error
 
 .. http:post:: /conversations/(str:sender_id)/respond
 
@@ -330,7 +147,8 @@ Endpoints
       This endpoint will be removed in the future. Rather consider using
       the ``RestInput`` channel. When added to core, it will provide you
       an endpoint at ``/webhooks/rest/webhook`` that returns the same
-      output as this endpoint.
+      output as this endpoint. The only difference is, that you need to send
+      the message as ``{"message": }"<your text to parse>"}``.
 
    Notify the dialogue engine that the user posted a new message, and get
    a list of response messages the bot should send back.

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -303,6 +303,9 @@ class BotUttered(Event):
 class SlotSet(Event):
     """The user has specified their preference for the value of a ``slot``.
 
+    Every slot has a name and a value. This event can be used to set a
+    value for a slot on a conversation.
+
     As a side effect the ``Tracker``'s slots will be updated so
     that ``tracker.slots[key]=value``."""
 
@@ -365,7 +368,9 @@ class SlotSet(Event):
 class Restarted(Event):
     """Conversation should start over & history wiped.
 
-    As a side effect the ``Tracker`` will be reinitialised."""
+    Instead of deleting all events, this event can be used to reset the
+    trackers state (e.g. ignoring any past user messages & resetting all
+    the slots)."""
 
     type_name = "restart"
 
@@ -418,9 +423,11 @@ class UserUtteranceReverted(Event):
 
 # noinspection PyProtectedMember
 class AllSlotsReset(Event):
-    """Conversation should start over & history wiped.
+    """All Slots are reset to their initial values.
 
-    As a side effect the ``Tracker`` will be reinitialised."""
+    If you want to keep the dialogue history and only want to reset the
+    slots, you can use this event to set all the slots to their initial
+    values."""
 
     type_name = "reset_slots"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,12 +8,13 @@ from datetime import datetime
 import copy
 
 import pytest
-
+from dateutil import parser
 from rasa_core.events import (
     Event, UserUttered, SlotSet, Restarted,
     ActionExecuted, AllSlotsReset,
     ReminderScheduled, ConversationResumed, ConversationPaused,
-    StoryExported, ActionReverted, BotUttered, FollowupAction)
+    StoryExported, ActionReverted, BotUttered, FollowupAction,
+    UserUtteranceReverted, AgentUttered)
 
 
 @pytest.mark.parametrize("one_event,another_event", [
@@ -41,6 +42,9 @@ from rasa_core.events import (
     (ActionReverted(),
      None),
 
+    (UserUtteranceReverted(),
+     None),
+
     (ActionExecuted("my_action"),
      ActionExecuted("my_other_action")),
 
@@ -49,6 +53,9 @@ from rasa_core.events import (
 
     (BotUttered("my_text", "my_data"),
      BotUttered("my_other_test", "my_other_data")),
+
+    (AgentUttered("my_text", "my_data"),
+     AgentUttered("my_other_test", "my_other_data")),
 
     (ReminderScheduled("my_action", datetime.now()),
      ReminderScheduled("my_other_action", datetime.now())),
@@ -90,11 +97,15 @@ def test_event_has_proper_implementation(one_event, another_event):
 
     ActionReverted(),
 
+    UserUtteranceReverted(),
+
     ActionExecuted("my_action"),
 
     FollowupAction("my_action"),
 
     BotUttered("my_text", "my_data"),
+
+    AgentUttered("my_text", "my_data"),
 
     ReminderScheduled("my_action", datetime.now()),
 
@@ -104,3 +115,171 @@ def test_dict_serialisation(one_event):
     evt_dict = one_event.as_dict()
     recovered_event = Event.from_parameters(evt_dict)
     assert hash(one_event) == hash(recovered_event)
+
+
+def test_json_parse_setslot():
+    # DOCS MARKER SetSlot
+    evt = \
+        {
+            'event': 'slot',
+            'name': 'departure_airport',
+            'value': 'BER',
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == SlotSet("departure_airport", "BER")
+
+
+def test_json_parse_restarted():
+    # DOCS MARKER Restarted
+    evt = \
+        {
+            'event': 'restart'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == Restarted()
+
+
+def test_json_parse_reset():
+    # DOCS MARKER AllSlotsReset
+    evt = \
+        {
+            'event': 'reset_slots'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == AllSlotsReset()
+
+
+def test_json_parse_user():
+    # DOCS MARKER UserUttered
+    evt = \
+        {
+            'event': 'user',
+            'text': 'Hey',
+            'parse_data': {
+                'intent': {'name': 'greet', 'confidence': 0.9},
+                'entities': []
+            }
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == UserUttered(
+            "Hey",
+            intent={"name": "greet",
+                    "confidence": 0.9},
+            entities=[],
+            parse_data={
+                "intent": {"name": "greet", "confidence": 0.9},
+                "entities": []
+            })
+
+
+def test_json_parse_bot():
+    # DOCS MARKER BotUttered
+    evt = \
+        {
+            'event': 'bot',
+            'text': 'Hey there!',
+            'data': {}
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == BotUttered("Hey there!", {})
+
+
+def test_json_parse_rewind():
+    # DOCS MARKER UserUtteranceReverted
+    evt = \
+        {
+            'event': 'rewind'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == UserUtteranceReverted()
+
+
+def test_json_parse_reminder():
+    # DOCS MARKER ReminderScheduled
+    evt = \
+        {
+            'event': 'reminder',
+            'action': 'my_action',
+            'date_time': '2018-09-03T11:41:10.128172',
+            'name': 'my_reminder',
+            'kill_on_user_msg': True
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == ReminderScheduled(
+            "my_action",
+            parser.parse('2018-09-03T11:41:10.128172'),
+            name='my_reminder',
+            kill_on_user_message=True)
+
+
+def test_json_parse_undo():
+    # DOCS MARKER ActionReverted
+    evt = \
+        {
+            'event': 'undo',
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == ActionReverted()
+
+
+def test_json_parse_export():
+    # DOCS MARKER StoryExported
+    evt = \
+        {
+            'event': 'export',
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == StoryExported()
+
+
+def test_json_parse_followup():
+    # DOCS MARKER FollowupAction
+    evt = \
+        {
+            'event': 'followup',
+            'name': 'my_action'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == FollowupAction("my_action")
+
+
+def test_json_parse_pause():
+    # DOCS MARKER ConversationPaused
+    evt = \
+        {
+            'event': 'pause',
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == ConversationPaused()
+
+
+def test_json_parse_resume():
+    # DOCS MARKER ConversationResumed
+    evt = \
+        {
+            'event': 'resume',
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == ConversationResumed()
+
+
+def test_json_parse_action():
+    # DOCS MARKER ActionExecuted
+    evt = \
+        {
+            'event': 'action',
+            'name': 'my_action'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == ActionExecuted("my_action")
+
+
+def test_json_parse_agent():
+    # DOCS MARKER AgentUttered
+    evt = \
+        {
+            'event': 'agent',
+            'text': 'Hey, how are you?'
+        }
+    # DOCS END
+    assert Event.from_parameters(evt) == AgentUttered("Hey, how are you?")


### PR DESCRIPTION
**Proposed changes**:
- list all events and their json formats on the events help page
- removed documentation for `/parse` endpoint, as it does not exist anymore (fixes #924)
- added tests for the json parsing


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
