### PR TITLE
Update interactive learning docs #935

### DIFF
--- a/docs/interactive_learning.rst
+++ b/docs/interactive_learning.rst
@@ -26,10 +26,10 @@ Run the following to start interactive learning:
 
    python -m rasa_core_sdk.endpoint --actions actions&
 
-   python -m rasa_core.run \
-     --interactive -d models/dialogue \
-     --stories-out stories_interactive.md \
-     -u models/default/nlu
+   python -m rasa_core.train \
+     --online -o models/dialogue \
+     -d domain.yml -s stories.md \
+     --endpoints endpoints.yml
 
 The first command starts the action server (see :ref:`customactions`).
 


### PR DESCRIPTION
**Proposed changes**:
- Current documentation about Interactive Learning seems outdated as the rasa_core.run does not handle this funcionality and thus does not have the --interactive and --stories-out parameters. Proper command execution should be:

```
python -m rasa_core.train \
  --online --dump_stories \
  -d domain.yml -s stories.md \
  -o models/dialogue \
  --endpoints endpoints.yml 
```

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [X] updated the documentation
- [ ] updated the changelog
