### PR TITLE
Daemonize threaded processes used for console I/O

### DIFF
--- a/rasa_core/run.py
+++ b/rasa_core/run.py
@@ -156,6 +156,7 @@ def start_cmdline_io(server_url, on_finish, **kwargs):
 
     p = Thread(target=console.record_messages,
                kwargs=kwargs)
+    p.setDaemon(True)
     p.start()
 
 

--- a/rasa_core/training/online.py
+++ b/rasa_core/training/online.py
@@ -886,6 +886,7 @@ def _start_online_learning_io(endpoint, on_finish, finetune=False):
                    "endpoint": endpoint,
                    "on_finish": on_finish,
                    "finetune": finetune})
+    p.setDaemon(True)
     p.start()
 
 


### PR DESCRIPTION
**Proposed changes**:
If you wrap `run.serve_application`  or `training.online.serve_application` in a custom CLI tool (or any other kind of application) and use console I/O, this application will currently not exit cleanly on `SIGINT` as the child processes summoned by rasa are not running as daemons and at the same time noone is listening to any signals in order to shut them down manually.

This means it currently requires two SIGINTs for the parent application to exit (which unfortunately apparently also kills/freezes Conda on Windows on the second signal).

To fix this condition, have the child processes run daemonized (as already done in  `agent.start_model_pulling_in_worker`).

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
