### PR TITLE
Added more informative link to docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,8 @@ Fixed
 -----
 - fixed an issue with boolean slots where False and None had the same value
   (breaking model compatibility with models that use a boolean slot)
+- Software 2.0 link on interactive learning documentation page went to Tesla's homepage, now it links to Karpathy
+  blogpost
 
 [0.11.4] - 2018-09-19
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/interactive_learning.rst
+++ b/docs/interactive_learning.rst
@@ -11,7 +11,7 @@ to it. It is a powerful tool! Interactive learning is a powerful way
 to explore what your bot can do, and the easiest way to fix any mistakes
 it makes. One advantage of machine learning based dialogue is that when
 your bot doesn't know how to do something yet, you can just teach it!
-Some people are calling this `Software 2.0 <https://tesla.com>`_.
+Some people are calling this `Software 2.0 <https://medium.com/@karpathy/software-2-0-a64152b37c35>`_.
 
 
 1. Load up an existing bot


### PR DESCRIPTION
**Proposed changes**:
- Software 2.0 hyperlink in the Interactive Learning documentation went to the Tesla homepage, now it directs to a blogpost by Andrej Karpathy on Medium

**Status (please check what you already did)**:
- [] made PR ready for code review
- [] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
