### PR TITLE
rename online to interactive learning #1057

### DIFF
--- a/docs/interactive_learning.rst
+++ b/docs/interactive_learning.rst
@@ -27,7 +27,7 @@ Run the following to start interactive learning:
    python -m rasa_core_sdk.endpoint --actions actions&
 
    python -m rasa_core.train \
-     --online -o models/dialogue \
+     --interactive -o models/dialogue \
      -d domain.yml -s stories.md \
      --endpoints endpoints.yml
 

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -20,7 +20,7 @@ from rasa_core.policies import FallbackPolicy
 from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.memoization import MemoizationPolicy
 from rasa_core.run import AvailableEndpoints
-from rasa_core.training import online
+from rasa_core.training import interactive
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ def create_argument_parser():
             '--core',
             default=None,
             help="path to load a pre-trained model instead of training (for "
-                 "online mode only)")
+                 "interactive mode only)")
 
     parser.add_argument(
             '-o', '--out',
@@ -87,10 +87,10 @@ def create_argument_parser():
             default=20,
             help="number of training samples to put into one training batch")
     parser.add_argument(
-            '--online',
+            '--interactive',
             default=False,
             action='store_true',
-            help="enable online training")
+            help="enable interactive training")
     parser.add_argument(
             '--finetune',
             default=False,
@@ -218,9 +218,9 @@ if __name__ == '__main__':
                                                      _endpoints.nlu)
 
     if cmdline_args.core:
-        if not cmdline_args.online:
+        if not cmdline_args.interactive:
             raise ValueError("--core can only be used together with the"
-                             "--online flag.")
+                             "--interactive flag.")
         else:
             logger.info("loading a pre-trained model. ",
                         "all training-related parameters will be ignored")
@@ -238,5 +238,5 @@ if __name__ == '__main__':
                                       cmdline_args.dump_stories,
                                       additional_arguments)
 
-    if cmdline_args.online:
-        online.run_online_learning(_agent, finetune=cmdline_args.finetune)
+    if cmdline_args.interactive:
+        interactive.run_interactive_learning(_agent, finetune=cmdline_args.finetune)

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -877,9 +877,9 @@ def record_messages(endpoint,  # type: EndpointConfig
             on_finish()
 
 
-def _start_online_learning_io(endpoint, on_finish, finetune=False):
+def _start_interactive_learning_io(endpoint, on_finish, finetune=False):
     # type: (EndpointConfig, Callable[[], None], bool) -> None
-    """Start the online learning message recording in a separate thread."""
+    """Start the interactive learning message recording in a separate thread."""
 
     p = Thread(target=record_messages,
                kwargs={
@@ -892,7 +892,7 @@ def _start_online_learning_io(endpoint, on_finish, finetune=False):
 
 def _serve_application(app, finetune=False, serve_forever=True):
     # type: (Flask, bool, bool) -> WSGIServer
-    """Start a core server and attach the online learning IO."""
+    """Start a core server and attach the interactive learning IO."""
 
     http_server = WSGIServer(('0.0.0.0', DEFAULT_SERVER_PORT), app)
     logger.info("Rasa Core server is up and running on "
@@ -900,7 +900,7 @@ def _serve_application(app, finetune=False, serve_forever=True):
     http_server.start()
 
     endpoint = EndpointConfig(url=DEFAULT_SERVER_URL)
-    _start_online_learning_io(endpoint, http_server.stop, finetune=finetune)
+    _start_interactive_learning_io(endpoint, http_server.stop, finetune=finetune)
 
     if serve_forever:
         try:
@@ -911,9 +911,9 @@ def _serve_application(app, finetune=False, serve_forever=True):
     return http_server
 
 
-def run_online_learning(agent, finetune=False, serve_forever=True):
+def run_interactive_learning(agent, finetune=False, serve_forever=True):
     # type: (Agent, bool, bool) -> WSGIServer
-    """Start the online learning with the model of the agent."""
+    """Start the interactive learning with the model of the agent."""
 
     app = server.create_app(agent)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,7 +9,7 @@ import sys
 
 from rasa_core import training
 from rasa_core.agent import Agent
-from rasa_core.training import online
+from rasa_core.training import interactive
 from rasa_core.events import ActionExecuted
 from tests import utilities
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -130,7 +130,8 @@ def test_is_listening_for_messages(mock_endpoint):
     httpretty.register_uri(httpretty.GET, url, body=tracker_dump)
 
     httpretty.enable()
-    is_listening = interactive.is_listening_for_message(sender_id, mock_endpoint)
+    is_listening = interactive.is_listening_for_message(sender_id,
+                                                        mock_endpoint)
     httpretty.disable()
 
     assert is_listening

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -4,7 +4,7 @@ import uuid
 from httpretty import httpretty
 
 from rasa_core import utils
-from rasa_core.training import online
+from rasa_core.training import interactive
 from rasa_core.utils import EndpointConfig
 
 
@@ -21,7 +21,7 @@ def test_send_message(mock_endpoint):
     httpretty.register_uri(httpretty.POST, url, body='{}')
 
     httpretty.enable()
-    online.send_message(mock_endpoint, sender_id, "Hello")
+    interactive.send_message(mock_endpoint, sender_id, "Hello")
     httpretty.disable()
 
     b = httpretty.latest_requests[-1].body.decode("utf-8")
@@ -40,7 +40,7 @@ def test_request_prediction(mock_endpoint):
     httpretty.register_uri(httpretty.POST, url, body='{}')
 
     httpretty.enable()
-    online.request_prediction(mock_endpoint, sender_id)
+    interactive.request_prediction(mock_endpoint, sender_id)
     httpretty.disable()
 
     b = httpretty.latest_requests[-1].body.decode("utf-8")
@@ -58,7 +58,7 @@ def test_bot_output_format():
                 {"title": "no", "payload": "/no"}]
         }
     }
-    formatted = online.format_bot_output(message)
+    formatted = interactive.format_bot_output(message)
     assert formatted == ("Hello!\n"
                          "Image: http://example.com/myimage.png\n"
                          "Attachment: My Attachment\n"
@@ -70,7 +70,7 @@ def test_latest_user_message():
     tracker_dump = "data/test_trackers/tracker_moodbot.json"
     tracker_json = json.loads(utils.read_file(tracker_dump))
 
-    m = online.latest_user_message(tracker_json.get("events"))
+    m = interactive.latest_user_message(tracker_json.get("events"))
 
     assert m is not None
     assert m["event"] == "user"
@@ -78,7 +78,7 @@ def test_latest_user_message():
 
 
 def test_latest_user_message_on_no_events():
-    m = online.latest_user_message([])
+    m = interactive.latest_user_message([])
 
     assert m is None
 
@@ -88,14 +88,14 @@ def test_all_events_before_user_msg():
     tracker_json = json.loads(utils.read_file(tracker_dump))
     evts = tracker_json.get("events")
 
-    m = online.all_events_before_latest_user_msg(evts)
+    m = interactive.all_events_before_latest_user_msg(evts)
 
     assert m is not None
     assert m == evts[:4]
 
 
 def test_all_events_before_user_msg_on_no_events():
-    assert online.all_events_before_latest_user_msg([]) == []
+    assert interactive.all_events_before_latest_user_msg([]) == []
 
 
 def test_print_history(mock_endpoint):
@@ -109,7 +109,7 @@ def test_print_history(mock_endpoint):
     httpretty.register_uri(httpretty.GET, url, body=tracker_dump)
 
     httpretty.enable()
-    online._print_history(sender_id, mock_endpoint)
+    interactive._print_history(sender_id, mock_endpoint)
     httpretty.disable()
 
     b = httpretty.latest_requests[-1].body.decode("utf-8")
@@ -130,7 +130,7 @@ def test_is_listening_for_messages(mock_endpoint):
     httpretty.register_uri(httpretty.GET, url, body=tracker_dump)
 
     httpretty.enable()
-    is_listening = online.is_listening_for_message(sender_id, mock_endpoint)
+    is_listening = interactive.is_listening_for_message(sender_id, mock_endpoint)
     httpretty.disable()
 
     assert is_listening
@@ -143,7 +143,7 @@ def test_splitting_conversation_at_restarts():
     evts.insert(2, {"event": "restart"})
     evts.append({"event": "restart"})
 
-    split = online._split_conversation_at_restarts(evts)
+    split = interactive._split_conversation_at_restarts(evts)
     assert len(split) == 2
     assert [e for s in split for e in s] == evts_wo_restarts
     assert len(split[0]) == 2
@@ -159,7 +159,7 @@ def test_as_md_message():
                       "value": "rasa"}],
         "intent": {"name": "greeting", "confidence": 0.9}
     }
-    md = online._as_md_message(parse_data)
+    md = interactive._as_md_message(parse_data)
     assert md == "Hello there [rasa](name)."
 
 
@@ -174,8 +174,8 @@ def test_validate_user_message():
             "intent": {"name": "greeting", "confidence": 0.9}
         }
     }
-    assert online._validate_user_regex(parse_data, ["greeting", "goodbye"])
-    assert not online._validate_user_regex(parse_data, ["goodbye"])
+    assert interactive._validate_user_regex(parse_data, ["greeting", "goodbye"])
+    assert not interactive._validate_user_regex(parse_data, ["goodbye"])
 
 
 def test_undo_latest_msg(mock_endpoint):
@@ -194,12 +194,12 @@ def test_undo_latest_msg(mock_endpoint):
     httpretty.register_uri(httpretty.PUT, replace_url)
 
     httpretty.enable()
-    online._undo_latest(sender_id, mock_endpoint)
+    interactive._undo_latest(sender_id, mock_endpoint)
     httpretty.disable()
 
     b = httpretty.latest_requests[-1].body.decode("utf-8")
 
-    # this should be the events the online call send to the endpoint
+    # this should be the events the interactive call send to the endpoint
     # these events should have the last utterance omitted
     replaced_evts = json.loads(b)
     assert len(replaced_evts) == 6


### PR DESCRIPTION
**Proposed changes**:
- fixes https://github.com/RasaHQ/rasa_core/issues/1057
- changes every occurrence of 'online' learning in the codebase to 'interactive', except within the policy / ensemble where online training is really the correct term.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
