### PR TITLE
return action confidence when serialising. fixes #623

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 Added
 -----
 - openapi documentation of server API
-
+- added action prediction confidence & policy to ``ActionExecuted`` event
 
 Changed
 -------

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -31,7 +31,9 @@
     {
       "timestamp": 1517821726.211031,
       "event": "action",
-      "name": "action_listen"
+      "name": "action_listen",
+      "policy": null,
+      "confidence": null
     },
     {
       "timestamp": 1517821726.200036,
@@ -64,12 +66,16 @@
     {
       "timestamp": 1517821726.200373,
       "event": "action",
-      "name": "utter_greet"
+      "name": "utter_greet",
+      "policy": null,
+      "confidence": null
     },
     {
       "timestamp": 1517821726.211038,
       "event": "action",
-      "name": "action_listen"
+      "name": "action_listen",
+      "policy": null,
+      "confidence": null
     },
     {
       "timestamp": 1517821726.209836,
@@ -102,12 +108,16 @@
     {
       "timestamp": 1517821726.209908,
       "event": "action",
-      "name": "utter_happy"
+      "name": "utter_happy",
+      "policy": "policy_1_KerasPolicy",
+      "confidence": 0.8
     },
     {
       "timestamp": 1517821726.211042,
       "event": "action",
-      "name": "action_listen"
+      "name": "action_listen",
+      "policy": "policy_2_MemoizationPolicy",
+      "confidence": 1.0
     }
   ]
 }

--- a/docs/_static/spec/server.yml
+++ b/docs/_static/spec/server.yml
@@ -929,6 +929,12 @@ components:
           name:
             type: string
             description: Action name
+          policy:
+            type: string
+            description: Policy that predicted the action
+          confidence:
+            type: number
+            description: Confidence of the prediction
         required: ["event", "name"]
     agent:
       allOf:

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -697,18 +697,17 @@ class ActionExecuted(Event):
     def __init__(self,
                  action_name,
                  policy=None,
-                 policy_confidence=None,
+                 confidence=None,
                  timestamp=None):
         self.action_name = action_name
         self.policy = policy
-        self.policy_confidence = policy_confidence
+        self.confidence = confidence
         self.unpredictable = False
         super(ActionExecuted, self).__init__(timestamp)
 
     def __str__(self):
-        return ("ActionExecuted(action: {}, policy: {}, policy_confidence: {})"
-                "".format(self.action_name, self.policy,
-                          self.policy_confidence))
+        return ("ActionExecuted(action: {}, policy: {}, confidence: {})"
+                "".format(self.action_name, self.policy, self.confidence))
 
     def __hash__(self):
         return hash(self.action_name)
@@ -728,13 +727,17 @@ class ActionExecuted(Event):
 
         return [ActionExecuted(parameters.get("name"),
                                parameters.get("policy"),
-                               parameters.get("policy_confidence"),
+                               parameters.get("confidence"),
                                parameters.get("timestamp")
                                )]
 
     def as_dict(self):
         d = super(ActionExecuted, self).as_dict()
-        d.update({"name": self.action_name})
+        d.update({
+            "name": self.action_name,
+            "policy": self.policy,
+            "confidence": self.confidence
+        })
         return d
 
     def apply_to(self, tracker):

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -388,7 +388,7 @@ class MessageProcessor(object):
             dispatcher.latest_bot_messages = []
 
     def _log_action_on_tracker(self, tracker, action_name, events, policy,
-                               policy_confidence):
+                               confidence):
         # Ensures that the code still works even if a lazy programmer missed
         # to type `return []` at the end of an action or the run method
         # returns `None` for some other reason.
@@ -402,8 +402,7 @@ class MessageProcessor(object):
 
         if action_name is not None:
             # log the action and its produced events
-            tracker.update(ActionExecuted(action_name, policy,
-                                          policy_confidence))
+            tracker.update(ActionExecuted(action_name, policy, confidence))
 
         for e in events:
             # this makes sure the events are ordered by timestamp -

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -101,6 +101,8 @@ def test_event_has_proper_implementation(one_event, another_event):
 
     ActionExecuted("my_action"),
 
+    ActionExecuted("my_action", "policy_1_KerasPolicy", 0.8),
+
     FollowupAction("my_action"),
 
     BotUttered("my_text", "my_data"),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -85,6 +85,8 @@ def test_requesting_non_existent_tracker(app):
     assert content["slots"] == {"location": None, "cuisine": None}
     assert content["sender_id"] == "madeupid"
     assert content["events"] == [{"event": "action",
+                                  "policy": None,
+                                  "confidence": None,
                                   "name": "action_listen",
                                   "timestamp": 1514764800}]
     assert content["latest_message"] == {"text": None,


### PR DESCRIPTION
**Proposed changes**:
- return action confidence and policy when serializing `ActionExecuted` events. fixes #623

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
