### PR TITLE
import str backport to support unicode in cat slot. fixes #774C

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 -----
 - fixed an issue with boolean slots where False and None had the same value
   (breaking model compatibility with models that use a boolean slot)
+- properly handle non ascii categorical slot values, e.g. ``大于100亿元``
 
 [0.11.8] - 2018-09-28
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/slots.py
+++ b/rasa_core/slots.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from builtins import str
+
 import logging
 
 from rasa_core import utils


### PR DESCRIPTION
**Proposed changes**:
- import str backport to support unicode in cat slot. fixes #774C

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
