### PR TITLE
Use utf8 everywhere for file IO. fixes #1041

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 -----
 - fixed an issue with boolean slots where False and None had the same value
   (breaking model compatibility with models that use a boolean slot)
+- use utf8 everywhere when handling file IO
 
 [0.11.8] - 2018-09-28
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/domain.py
+++ b/rasa_core/domain.py
@@ -430,9 +430,8 @@ class Domain(object):
         # type: (Text) -> Dict[Text, Any]
         """Load a domains specification from a dumped model directory."""
 
-        matadata_path = os.path.join(path, 'domain.json')
-        with io.open(matadata_path) as f:
-            specification = json.loads(f.read())
+        metadata_path = os.path.join(path, 'domain.json')
+        specification = json.loads(utils.read_file(metadata_path))
         return specification
 
     def compare_with_specification(self, path):

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -183,7 +183,7 @@ def log_failed_stories(failed, failed_output):
     if not failed_output:
         return
 
-    with io.open(failed_output, 'w') as f:
+    with io.open(failed_output, 'w', encoding="utf-8") as f:
         if len(failed) == 0:
             f.write("<!-- All stories passed -->")
         else:

--- a/rasa_core/featurizers.py
+++ b/rasa_core/featurizers.py
@@ -430,7 +430,7 @@ class TrackerFeaturizer(object):
     def persist(self, path):
         featurizer_file = os.path.join(path, "featurizer.json")
         utils.create_dir_for_file(featurizer_file)
-        with io.open(featurizer_file, 'w') as f:
+        with io.open(featurizer_file, 'w', encoding="utf-8") as f:
             # noinspection PyTypeChecker
             f.write(str(jsonpickle.encode(self)))
 
@@ -438,9 +438,7 @@ class TrackerFeaturizer(object):
     def load(path):
         featurizer_file = os.path.join(path, "featurizer.json")
         if os.path.isfile(featurizer_file):
-            with io.open(featurizer_file, 'r') as f:
-                _json = f.read()
-            return jsonpickle.decode(_json)
+            return jsonpickle.decode(utils.read_file(featurizer_file))
         else:
             logger.error("Couldn't load featurizer for policy. "
                          "File '{}' doesn't exist.".format(featurizer_file))

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -147,8 +147,7 @@ class PolicyEnsemble(object):
     @classmethod
     def load_metadata(cls, path):
         metadata_path = os.path.join(path, 'policy_metadata.json')
-        with io.open(os.path.abspath(metadata_path)) as f:
-            metadata = json.loads(f.read())
+        metadata = json.loads(utils.read_file(os.path.abspath(metadata_path)))
         return metadata
 
     @staticmethod

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -142,7 +142,6 @@ class FallbackPolicy(Policy):
         if os.path.exists(path):
             meta_path = os.path.join(path, "fallback_policy.json")
             if os.path.isfile(meta_path):
-                with io.open(meta_path) as f:
-                    meta = json.loads(f.read())
+                meta = json.loads(utils.read_file(meta_path))
 
         return cls(**meta)

--- a/rasa_core/policies/keras_policy.py
+++ b/rasa_core/policies/keras_policy.py
@@ -228,8 +228,7 @@ class KerasPolicy(Policy):
             featurizer = TrackerFeaturizer.load(path)
             meta_path = os.path.join(path, "keras_policy.json")
             if os.path.isfile(meta_path):
-                with io.open(meta_path) as f:
-                    meta = json.loads(f.read())
+                meta = json.loads(utils.read_file(meta_path))
 
                 model_file = os.path.join(path, meta["model"])
 

--- a/rasa_core/policies/memoization.py
+++ b/rasa_core/policies/memoization.py
@@ -232,8 +232,7 @@ class MemoizationPolicy(Policy):
         featurizer = TrackerFeaturizer.load(path)
         memorized_file = os.path.join(path, 'memorized_turns.json')
         if os.path.isfile(memorized_file):
-            with io.open(memorized_file) as f:
-                data = json.loads(f.read())
+            data = json.loads(utils.read_file(memorized_file))
             return cls(featurizer=featurizer, lookup=data["lookup"])
         else:
             logger.info("Couldn't load memoization for policy. "

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -338,7 +338,7 @@ class DialogueStateTracker(object):
         # type: (Text) -> None
         """Dump the tracker as a story to a file."""
 
-        with io.open(export_path, 'a') as f:
+        with io.open(export_path, 'a', encoding="utf-8") as f:
             f.write(self.export_stories() + "\n")
 
     ###

--- a/rasa_core/training/dsl.py
+++ b/rasa_core/training/dsl.py
@@ -148,7 +148,7 @@ class StoryFileReader(object):
         """Given a md file reads the contained stories."""
 
         try:
-            with io.open(filename, "r") as f:
+            with io.open(filename, "r", encoding="utf-8") as f:
                 lines = f.readlines()
             reader = StoryFileReader(domain, interpreter, template_variables)
             return reader.process_lines(lines)

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -517,7 +517,7 @@ def _request_export_stories_info():
 
     def validate_path(path):
         try:
-            with io.open(path, "a"):
+            with io.open(path, "a", encoding="utf-8"):
                 return True
         except Exception as e:
             return "Failed to open file. {}".format(e)
@@ -570,7 +570,7 @@ def _write_stories_to_file(export_file_path, sender_id, endpoint):
 
     sub_conversations = _split_conversation_at_restarts(evts)
 
-    with io.open(export_file_path, 'a') as f:
+    with io.open(export_file_path, 'a', encoding="utf-8") as f:
         for conversation in sub_conversations:
             parsed_events = events.deserialise_events(conversation)
             s = Story.from_events(parsed_events)

--- a/rasa_core/training/structures.py
+++ b/rasa_core/training/structures.py
@@ -202,7 +202,7 @@ class Story(object):
             return story_content
 
     def dump_to_file(self, filename, flat=False):
-        with io.open(filename, "a") as f:
+        with io.open(filename, "a", encoding="utf-8") as f:
             f.write(self.as_story_string(flat))
 
 

--- a/rasa_core/utils.py
+++ b/rasa_core/utils.py
@@ -107,7 +107,7 @@ def dump_obj_as_str_to_file(filename, text):
     # type: (Text, Text) -> None
     """Dump a text to a file."""
 
-    with io.open(filename, 'w') as f:
+    with io.open(filename, 'w', encoding="utf-8") as f:
         # noinspection PyTypeChecker
         f.write(str(text))
 
@@ -547,7 +547,7 @@ def read_lines(filename, max_line_limit=None, line_pattern=".*"):
 
     line_filter = re.compile(line_pattern)
 
-    with io.open(filename, 'r') as f:
+    with io.open(filename, 'r', encoding="utf-8") as f:
         num_messages = 0
         for line in f:
             m = line_filter.match(line)

--- a/tests/test_dialogues.py
+++ b/tests/test_dialogues.py
@@ -10,6 +10,7 @@ import io
 import jsonpickle
 import pytest
 
+from rasa_core import utils
 from rasa_core.domain import Domain
 from rasa_core.tracker_store import InMemoryTrackerStore
 from tests.utilities import tracker_from_dialogue_file
@@ -17,9 +18,7 @@ from tests.utilities import tracker_from_dialogue_file
 
 @pytest.mark.parametrize("filename", glob.glob('data/test_dialogues/*json'))
 def test_dialogue_serialisation(filename):
-    print("testing file: {0}".format(filename))
-    with io.open(filename, "r") as f:
-        dialogue_json = f.read()
+    dialogue_json = utils.read_file(filename)
     restored = json.loads(dialogue_json)
     tracker = tracker_from_dialogue_file(filename)
     en_de_coded = json.loads(jsonpickle.encode(tracker.as_dialogue()))

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -61,7 +61,7 @@ def test_persist_and_read_test_story_graph(tmpdir, default_domain):
     graph = training.extract_story_graph("data/test_stories/stories.md",
                                          default_domain)
     out_path = tmpdir.join("persisted_story.md")
-    with io.open(out_path.strpath, "w") as f:
+    with io.open(out_path.strpath, "w", encoding="utf-8") as f:
         f.write(graph.as_story_string())
 
     recovered_trackers = training.load_data(

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -12,6 +12,7 @@ import sys
 import jsonpickle
 import six
 
+from rasa_core import utils
 from rasa_core.domain import Domain
 from rasa_core.trackers import DialogueStateTracker
 from tests.conftest import DEFAULT_DOMAIN_PATH
@@ -30,14 +31,12 @@ def tracker_from_dialogue_file(filename, domain=None):
 
 
 def read_dialogue_file(filename):
-    with io.open(filename, "r") as f:
-        dialogue_json = f.read()
-    return jsonpickle.loads(dialogue_json)
+    return jsonpickle.loads(utils.read_file(filename))
 
 
 def write_text_to_file(tmpdir, filename, text):
     path = tmpdir.join(filename).strpath
-    with io.open(path, "w") as f:
+    with io.open(path, "w", encoding="utf-8") as f:
         f.write(text)
     return path
 


### PR DESCRIPTION
**Proposed changes**:
- use utf8 everywhere for file IO. fixes #1041
- did not find a way to test this, as there doesn't seem to be a reliable way to change the default encoding used by io.open.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
