### PR TITLE
Add training date and time to policy metadata when persisting  Fixes #1104

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 -----
 - openapi documentation of server API
 - added action prediction confidence & policy to ``ActionExecuted`` event
+- both the date and the time at which a model was trained are now included in the policy's metadata when it is persisted
 
 Changed
 -------

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import sys
-import time
+import datetime
 from collections import defaultdict
 
 import numpy as np
@@ -40,7 +40,6 @@ class PolicyEnsemble(object):
         # type: (List[Policy], Optional[Dict]) -> None
         self.policies = policies
         self.training_trackers = None
-        self.date_trained = None
 
         if action_fingerprints:
             self.action_fingerprints = action_fingerprints
@@ -127,7 +126,7 @@ class PolicyEnsemble(object):
             "max_histories": self._max_histories(),
             "ensemble_name": self.__module__ + "." + self.__class__.__name__,
             "policy_names": policy_names,
-            "trained_at": self.date_trained
+            "trained_at": datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
         }
 
         utils.dump_obj_as_json_to_file(domain_spec_path, metadata)

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -40,6 +40,7 @@ class PolicyEnsemble(object):
         # type: (List[Policy], Optional[Dict]) -> None
         self.policies = policies
         self.training_trackers = None
+        self.date_trained = None
 
         if action_fingerprints:
             self.action_fingerprints = action_fingerprints
@@ -66,7 +67,7 @@ class PolicyEnsemble(object):
             for policy in self.policies:
                 policy.train(training_trackers, domain, **kwargs)
             self.training_trackers = training_trackers
-            self.date_trained = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+            self.date_trained = datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
         else:
             logger.info("Skipped training, because there are no "
                         "training samples.")
@@ -126,7 +127,7 @@ class PolicyEnsemble(object):
             "max_histories": self._max_histories(),
             "ensemble_name": self.__module__ + "." + self.__class__.__name__,
             "policy_names": policy_names,
-            "trained_at": datetime.datetime.now().strftime('%Y%m%d-%H%M%S')
+            "trained_at": self.date_trained
         }
 
         utils.dump_obj_as_json_to_file(domain_spec_path, metadata)

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -40,6 +40,7 @@ class PolicyEnsemble(object):
         # type: (List[Policy], Optional[Dict]) -> None
         self.policies = policies
         self.training_trackers = None
+        self.date_trained = None
 
         if action_fingerprints:
             self.action_fingerprints = action_fingerprints
@@ -66,6 +67,7 @@ class PolicyEnsemble(object):
             for policy in self.policies:
                 policy.train(training_trackers, domain, **kwargs)
             self.training_trackers = training_trackers
+            self.date_trained = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
         else:
             logger.info("Skipped training, because there are no "
                         "training samples.")
@@ -117,7 +119,6 @@ class PolicyEnsemble(object):
                 self.training_trackers)
 
         action_fingerprints = self._create_action_fingerprints(training_events)
-        date_trained = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
 
         metadata = {
             "action_fingerprints": action_fingerprints,
@@ -126,7 +127,7 @@ class PolicyEnsemble(object):
             "max_histories": self._max_histories(),
             "ensemble_name": self.__module__ + "." + self.__class__.__name__,
             "policy_names": policy_names,
-            "trained_at": date_trained
+            "trained_at": self.date_trained
         }
 
         utils.dump_obj_as_json_to_file(domain_spec_path, metadata)

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sys
+import time
 from collections import defaultdict
 
 import numpy as np
@@ -116,6 +117,7 @@ class PolicyEnsemble(object):
                 self.training_trackers)
 
         action_fingerprints = self._create_action_fingerprints(training_events)
+        date_trained = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
 
         metadata = {
             "action_fingerprints": action_fingerprints,
@@ -123,7 +125,8 @@ class PolicyEnsemble(object):
             "python": ".".join([str(s) for s in sys.version_info[:3]]),
             "max_histories": self._max_histories(),
             "ensemble_name": self.__module__ + "." + self.__class__.__name__,
-            "policy_names": policy_names
+            "policy_names": policy_names,
+            "trained_at": date_trained
         }
 
         utils.dump_obj_as_json_to_file(domain_spec_path, metadata)


### PR DESCRIPTION
- fixes #1104

**Proposed changes**:
- Added date to _persist_metadata() function of base policy ensemble

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
