### PR TITLE
Messengerfix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,29 @@ Fixed
 - properly handle non ascii categorical slot values, e.g. ``大于100亿元``
 - fixed HTTP server attempting to authenticate based on incorrect path to the correct JWT data field
 
+[0.11.11] - 2018-10-05
+^^^^^^^^^^^^^^^^^^^^^^
+
+Fixed
+-----
+- Add missing name() to facebook Messenger class
+
+
+[0.11.10] - 2018-10-05
+^^^^^^^^^^^^^^^^^^^^^^
+
+Fixed
+-----
+- backport fix to JWT schema
+
+
+[0.11.9] - 2018-10-04
+^^^^^^^^^^^^^^^^^^^^^
+
+Changed
+-------
+- pin tensorflow 1.10.0
+
 [0.11.8] - 2018-09-28
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/rasa_core/channels/facebook.py
+++ b/rasa_core/channels/facebook.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 class Messenger(BaseMessenger):
     """Implement a fbmessenger to parse incoming webhooks and send msgs."""
 
+    @classmethod
+    def name(cls):
+        return "facebook"
+
     def __init__(self, page_access_token, on_new_message):
         # type: (Text, Callable[[UserMessage], None]) -> None
 


### PR DESCRIPTION
**Proposed changes**:
- facebook channel has been broken since 0.11.6 due to a missing `name()` in the Messenger class
- fixes #1125 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
