### PR TITLE
Policy cofiguration via yaml file

### DIFF
--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -219,8 +219,7 @@ class PolicyEnsemble(object):
                         max_history=max_history),
                 KerasPolicy(
                         MaxHistoryTrackerFeaturizer(BinarySingleStateFeaturizer(),
-                                                    max_history=max_history))
-                ]
+                                                    max_history=max_history))]
 
         else:
 

--- a/rasa_core/policy_config.yaml
+++ b/rasa_core/policy_config.yaml
@@ -1,6 +1,0 @@
-# TODO specify policy config file in cmd args
-policies:
-  - name: KerasPolicy
-  - name: MemoizationPolicy
-  - name: FallbackPolicy
-    nlu_threshold: 0.8

--- a/rasa_core/policy_config.yaml
+++ b/rasa_core/policy_config.yaml
@@ -1,0 +1,6 @@
+# TODO specify policy config file in cmd args
+policies:
+  - name: KerasPolicy
+  - name: MemoizationPolicy
+  - name: FallbackPolicy
+    nlu_threshold: 0.8

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -138,7 +138,7 @@ def create_argument_parser():
                  "is of low confidence) this is the name of tje action that "
                  "will get triggered instead.")
     parser.add_argument(
-            '--policy_config',
+            '-p', '--policy_config',
             type=str,
             required=False,
             help="Policy specification yaml file."
@@ -177,7 +177,7 @@ def train_dialogue_model(domain_file, stories_file, output_path,
             KerasPolicy(
                     MaxHistoryTrackerFeaturizer(BinarySingleStateFeaturizer(),
                                                 max_history=max_history))]
-                                                
+
     else:
         policies = PolicyEnsemble.load_from_yaml(policy_config)
 

--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -17,6 +17,7 @@ from rasa_core.featurizers import (
     MaxHistoryTrackerFeaturizer, BinarySingleStateFeaturizer)
 from rasa_core.interpreter import NaturalLanguageInterpreter
 from rasa_core.policies import FallbackPolicy
+from rasa_core.policies.ensemble import PolicyEnsemble
 from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.memoization import MemoizationPolicy
 from rasa_core.run import AvailableEndpoints
@@ -155,19 +156,7 @@ def train_dialogue_model(domain_file, stories_file, output_path,
                                                 "core_threshold",
                                                 "fallback_action_name"})
 
-    policies = [
-        FallbackPolicy(
-                fallback_args.get("nlu_threshold",
-                                  DEFAULT_NLU_FALLBACK_THRESHOLD),
-                fallback_args.get("core_threshold",
-                                  DEFAULT_CORE_FALLBACK_THRESHOLD),
-                fallback_args.get("fallback_action_name",
-                                  DEFAULT_FALLBACK_ACTION)),
-        MemoizationPolicy(
-                max_history=max_history),
-        KerasPolicy(
-                MaxHistoryTrackerFeaturizer(BinarySingleStateFeaturizer(),
-                                            max_history=max_history))]
+    policies = PolicyEnsemble.load_from_yaml(policiy_config)
 
     agent = Agent(domain_file,
                   generator=endpoints.nlg,


### PR DESCRIPTION
This PR addresses #1030 

We can now have a `policy_config.yaml` such as:
```
policies:
- name: KerasPolicy
- name: FallbackPolicy
  intent_threshold: 0.3
  action_threshold: 0.4
- name: path.to.custom.policy.CustomPolicy
  arg1: val1
  arg2: val2
```

The name and location of the file containing this policy configuration information can be set with a cmd arg (`--policy_config` or `-p`). When the arg is not set, the Policies are set to be `KerasPolicy, MemoizationPolicy and FallbackPolicy`.

A few open questions from my side:
1. does the `load_from_yaml` function belong in `PolicyEnsemble`? Should it rather be in `utils, Agent or Policy`?
2. When both a `policy_config.yaml` and the cmd args specify values for the `FallbackPolicy` (such as `nlu_threshold, ...`) should the cmd arg or the value in the `policy_config.yaml` take precedence? Currently the value in `policy_config.yaml` takes precedence.
3. I did not include the possibility of setting `batch size` and `epochs` in the policy_config. The way I see it there is no issue setting these values on the command line. What we currently lack is a way to add custom policies. Do you nevertheless prefer to have the possibility of setting these options in the `policy_config.yaml`?

Note: I did not yet have the time to test this significantyl. I opened this PR because I would like to get your input early on.

Looking forward to your thoughts and feedback.
Cheers!
Tom