### PR TITLE
Update Interactive learning documentation

### DIFF
--- a/docs/interactive_learning.rst
+++ b/docs/interactive_learning.rst
@@ -29,8 +29,7 @@ Run the following to start interactive learning:
    python -m rasa_core.train \
      --interactive -o models/dialogue \
      -d domain.yml -s stories.md \
-     --endpoints endpoints.yml \
-     --nlu models/current/nlu (OPTIONAL)
+     --endpoints endpoints.yml 
      
 To include an existing model to identify intents use --nlu models/current/nlu in the above command. Else interactive learning will use a default REGEX to intentify default intents from the user input text. 
 

--- a/docs/interactive_learning.rst
+++ b/docs/interactive_learning.rst
@@ -29,7 +29,10 @@ Run the following to start interactive learning:
    python -m rasa_core.train \
      --interactive -o models/dialogue \
      -d domain.yml -s stories.md \
-     --endpoints endpoints.yml
+     --endpoints endpoints.yml \
+     --nlu models/current/nlu (OPTIONAL)
+     
+To include an existing model to identify intents use --nlu models/current/nlu in the above command. Else interactive learning will use a default REGEX to intentify default intents from the user input text. 
 
 The first command starts the action server (see :ref:`customactions`).
 


### PR DESCRIPTION
The documentation doesn't mention how to use a trained nlu model for intent classification with interactive learning. Although it is an intuitive command, people might not be able to figure it out so easily and just stay confused about why the intents from their model are not showing up.

**Proposed changes**:
- ...

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
