### PR TITLE
Evaluation improvements

### DIFF
--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -335,8 +335,7 @@ def _collect_action_executed_predictions(processor, partial_tracker, event,
                     "Model predicted a wrong action. Failed Story: "
                     "\n\n{}".format(partial_tracker.export_stories()))
     else:
-        correct_action_executed_event = ActionExecuted(event.action_name)
-        partial_tracker.update(correct_action_executed_event)
+        partial_tracker.update(event)
 
     return action_executed_eval_store, policy
 

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -334,7 +334,7 @@ def _collect_action_executed_predictions(processor, partial_tracker, event,
                                          fail_on_prediction_errors):
     action_executed_eval_store = EvaluationStore()
 
-    action, policy, confidence = processor.predict_next_action(partial_tracker)
+    action, policy, _ = processor.predict_next_action(partial_tracker)
 
     predicted = action.name()
     gold = event.action_name

--- a/rasa_core/evaluate.py
+++ b/rasa_core/evaluate.py
@@ -211,8 +211,7 @@ class EndToEndUserUtterance(UserUttered):
     `failed_stories.md` output file."""
 
     def as_story_string(self):
-        message = _md_format_message(self.text, self.intent,
-                                     self.entities)
+        message = _md_format_message(self.text, self.intent, self.entities)
         return "{}: {}".format(self.intent.get("name"), message)
 
 
@@ -336,7 +335,8 @@ def _collect_action_executed_predictions(processor, partial_tracker, event,
                     "Model predicted a wrong action. Failed Story: "
                     "\n\n{}".format(partial_tracker.export_stories()))
     else:
-        partial_tracker.update(event)
+        correct_action_executed_event = ActionExecuted(event.action_name)
+        partial_tracker.update(correct_action_executed_event)
 
     return action_executed_eval_store, policy
 

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -455,7 +455,7 @@ def create_app(agent,
     def evaluate_stories():
         """Evaluate stories against the currently loaded model."""
         tmp_file = rasa_nlu.utils.create_temporary_file(request.get_data(),
-                                                   mode='w+b')
+                                                        mode='w+b')
         use_e2e = utils.bool_arg('e2e', default=False)
         try:
             evaluation = run_story_evaluation(tmp_file, agent, use_e2e=use_e2e)


### PR DESCRIPTION
**Proposed changes**:
- partial tracker uses correct user utterance and correct action, regardless of prediction
- entities are excluded from evaluation metrics
- the failed stories output prints user messages in end-to-end form, regardless of whether prediction was correct or not


**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
