### PR TITLE
pass correct tracker store object #1277

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Added
 - ability to add tracker_store using endpoints.yml
 - ability load custom tracker store modules using the endpoints.yml
 - ability to add an event broker using an endpoint configuration file
+- raise an exception when ``server.py`` is used instead of ``rasa_core.run --enable-api``
 
 Changed
 -------

--- a/rasa_core/broker.py
+++ b/rasa_core/broker.py
@@ -35,10 +35,7 @@ class PikaProducer(EventChannel):
         if broker_config is None:
             return None
 
-        return cls(broker_config.url,
-                   broker_config.kwargs.get('username', None),
-                   broker_config.kwargs.get('password', None),
-                   broker_config.kwargs.get('queue', None))
+        return cls(broker_config.url, **broker_config.kwargs)
 
     def publish(self, event):
         self._open_connection()

--- a/rasa_core/run.py
+++ b/rasa_core/run.py
@@ -218,7 +218,7 @@ def load_agent(core_model, interpreter, endpoints,
                 generator=endpoints.nlg,
                 action_endpoint=endpoints.action,
                 model_server=endpoints.model,
-                tracker_store=endpoints.tracker_store,
+                tracker_store=tracker_store,
                 wait_time_between_pulls=wait_time_between_pulls
         )
     else:

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -19,10 +19,8 @@ from rasa_core import utils, constants
 from rasa_core.channels import CollectingOutputChannel, UserMessage
 from rasa_core.evaluate import run_story_evaluation
 from rasa_core.events import Event
-from rasa_core.interpreter import NaturalLanguageInterpreter
 from rasa_core.policies import PolicyEnsemble
 from rasa_core.trackers import DialogueStateTracker, EventVerbosity
-from rasa_core.utils import AvailableEndpoints
 from rasa_core.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -600,38 +598,5 @@ def create_app(agent,
 
 
 if __name__ == '__main__':
-    # Running as standalone python application
-    from rasa_core import run
-
-    arg_parser = run.create_argument_parser()
-    cmdline_args = arg_parser.parse_args()
-
-    logging.getLogger('werkzeug').setLevel(logging.WARN)
-    logging.getLogger('matplotlib').setLevel(logging.WARN)
-
-    utils.configure_colored_logging(cmdline_args.loglevel)
-    utils.configure_file_logging(cmdline_args.loglevel,
-                                 cmdline_args.log_file)
-
-    logger.warning("USING `rasa_core.server` is deprecated and will be "
-                   "removed in the future. Use `rasa_core.run --enable_api` "
-                   "instead.")
-
-    logger.info("Rasa process starting")
-
-    _endpoints = AvailableEndpoints.read_endpoints(cmdline_args.endpoints)
-    _interpreter = NaturalLanguageInterpreter.create(cmdline_args.nlu,
-                                                     _endpoints.nlu)
-    _agent = run.load_agent(cmdline_args.core,
-                            interpreter=_interpreter,
-                            endpoints=_endpoints)
-
-    run.serve_application(_agent,
-                          cmdline_args.connector,
-                          cmdline_args.port,
-                          cmdline_args.credentials,
-                          cmdline_args.cors,
-                          cmdline_args.auth_token,
-                          cmdline_args.enable_api,
-                          cmdline_args.jwt_secret,
-                          cmdline_args.jwt_method)
+    raise RuntimeError("Using `rasa_core.server` is not longer supported. "
+                       "Please use `rasa_core.run --enable_api` instead.")

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -598,5 +598,6 @@ def create_app(agent,
 
 
 if __name__ == '__main__':
-    raise RuntimeError("Using `rasa_core.server` is not longer supported. "
+    raise RuntimeError("Calling `rasa_core.server` directly is "
+                       "no longer supported. "
                        "Please use `rasa_core.run --enable_api` instead.")


### PR DESCRIPTION
**Proposed changes**:
- https://github.com/RasaHQ/rasa_core/issues/1277
- If no queue is present for the broker configuration, it overwrites the default queue with `None`. This should not be the case, the default value should be preserverd

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
