### PR TITLE
response code could be 304 when model is up to date

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -191,7 +191,7 @@ Rasa Core sends requests to your model server with an ``If-None-Match``
 header that contains the current model hash. If your model server can
 provide a model with a different hash from the one you sent, it should send it
 in as a zip file with an ``ETag`` header containing the new hash. If not, Rasa
-Core expects an empty response with a ``204`` status code.
+Core expects an empty response with a ``204`` or ``304`` status code.
 
 An example request Rasa Core might make to your model server looks like this:
 

--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -139,7 +139,8 @@ def _pull_model_and_fingerprint(model_server, model_directory, fingerprint):
     if response.status_code in [204, 304]:
         logger.debug("Model server returned {} status code, indicating "
                      "that no new model is available. "
-                     "Current fingerprint: {}".format(response.status_code, fingerprint))
+                     "Current fingerprint: {}"
+                     "".format(response.status_code, fingerprint))
         return response.headers.get("ETag")
     elif response.status_code == 404:
         logger.debug("Model server didn't find a model for our request. "

--- a/rasa_core/agent.py
+++ b/rasa_core/agent.py
@@ -136,10 +136,10 @@ def _pull_model_and_fingerprint(model_server, model_directory, fingerprint):
                        "".format(e))
         return None
 
-    if response.status_code == 204:
-        logger.debug("Model server returned 204 status code, indicating "
+    if response.status_code in [204, 304]:
+        logger.debug("Model server returned {} status code, indicating "
                      "that no new model is available. "
-                     "Current fingerprint: {}".format(fingerprint))
+                     "Current fingerprint: {}".format(response.status_code, fingerprint))
         return response.headers.get("ETag")
     elif response.status_code == 404:
         logger.debug("Model server didn't find a model for our request. "


### PR DESCRIPTION
**Proposed changes**:
- Server won't trigger an error message in case of 304 when trying to pull a model

**Status (please check what you already did)**:
- [ x] made PR ready for code review
- [ ] added some tests for the functionality
- [ x] updated the documentation
- [ ] updated the changelog
