### PR TITLE
Fix batch_size parameter in Keras policy

### DIFF
--- a/rasa_core/policies/keras_policy.py
+++ b/rasa_core/policies/keras_policy.py
@@ -73,7 +73,7 @@ class KerasPolicy(Policy):
 
         self.rnn_size = config['rnn_size']
         self.epochs = config['epochs']
-        self.batch_size = config['epochs']
+        self.batch_size = config['batch_size']
         self.validation_split = config['validation_split']
 
     @property


### PR DESCRIPTION
The Keras policy appears to be using the epochs parameter for both epochs and batch_size.  This appears to be incorrect (to me).