### PR TITLE
Ensemble.from_dict not working

### DIFF
--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -208,7 +208,8 @@ class PolicyEnsemble(object):
 
                 if featurizer_config.get('state_featurizer'):
                     state_featurizer_func, state_featurizer_config = \
-                                cls.get_state_featurizer_from_dict(featurizer_config)
+                                cls.get_state_featurizer_from_dict(
+                                    featurizer_config)
 
                     # override featurizer's state_featurizer
                     # with real state_featurizer class

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -226,7 +226,8 @@ class PolicyEnsemble(object):
 
         return policies
 
-    def get_featurizer_from_dict(self, policy):
+    @classmethod
+    def get_featurizer_from_dict(cls, policy):
         # policy can have only 1 featurizer
         if len(policy['featurizer']) > 1:
             raise InvalidPolicyConfig(
@@ -237,7 +238,8 @@ class PolicyEnsemble(object):
 
         return featurizer_func, featurizer_config
 
-    def get_state_featurizer_from_dict(self, featurizer_config):
+    @classmethod
+    def get_state_featurizer_from_dict(cls, featurizer_config):
         # featurizer can have only 1 state featurizer
         if len(featurizer_config['state_featurizer']) > 1:
             raise InvalidPolicyConfig(

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -208,7 +208,7 @@ class PolicyEnsemble(object):
 
                 if featurizer_config.get('state_featurizer'):
                     state_featurizer_func, state_featurizer_config = \
-                                cls.get_featurizer_from_dict(featurizer_config)
+                                cls.get_state_featurizer_from_dict(featurizer_config)
 
                     # override featurizer's state_featurizer
                     # with real state_featurizer class

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,22 +47,22 @@ def test_ensemble_from_dict():
         assert p.core_threshold == 0.7
 
     ensemble_dict = {'policies': [
-            {'epochs': 50, 'name': 'KerasPolicy', 'featurizer': [
-                {'max_history': 5, 'name': 'MaxHistoryTrackerFeaturizer',
-                 'state_featurizer': [
-                     {'name': 'BinarySingleStateFeaturizer'}]}]},
-            {'max_history': 5, 'name': 'MemoizationPolicy'},
-            {'core_threshold': 0.7, 'name': 'FallbackPolicy',
-             'nlu_threshold': 0.7,
-             'fallback_action_name': 'action_default_fallback'},
-            {'name': 'FormPolicy'}]}
+        {'epochs': 50, 'name': 'KerasPolicy', 'featurizer': [
+            {'max_history': 5, 'name': 'MaxHistoryTrackerFeaturizer',
+             'state_featurizer': [
+                 {'name': 'BinarySingleStateFeaturizer'}]}]},
+        {'max_history': 5, 'name': 'MemoizationPolicy'},
+        {'core_threshold': 0.7, 'name': 'FallbackPolicy',
+         'nlu_threshold': 0.7,
+         'fallback_action_name': 'action_default_fallback'},
+        {'name': 'FormPolicy'}]}
     ensemble = PolicyEnsemble.from_dict(ensemble_dict)
 
     # Check if all policies are present
     assert len(ensemble) == 4
     # MemoizationPolicy is parent of FormPolicy
-    assert any([isinstance(p, MemoizationPolicy) and
-        not isinstance(p, FormPolicy) for p in ensemble])
+    assert any([isinstance(p, MemoizationPolicy) and \
+                not isinstance(p, FormPolicy) for p in ensemble])
     assert any([isinstance(p, KerasPolicy) for p in ensemble])
     assert any([isinstance(p, FallbackPolicy) for p in ensemble])
     assert any([isinstance(p, FormPolicy) for p in ensemble])
@@ -70,7 +70,7 @@ def test_ensemble_from_dict():
     # Verify policy configurations
     for policy in ensemble:
         if isinstance(policy, MemoizationPolicy) \
-        and not isinstance(policy, FormPolicy):
+                and not isinstance(policy, FormPolicy):
             check_memoization(policy)
         elif isinstance(policy, KerasPolicy):
             check_keras(policy)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,10 @@ import pytest
 from tests.conftest import ExamplePolicy
 from rasa_core.config import load
 from rasa_core.policies.memoization import MemoizationPolicy
+from rasa_core.policies.keras_policy import KerasPolicy
+from rasa_core.policies.fallback import FallbackPolicy
+from rasa_core.policies.form_policy import FormPolicy
+from rasa_core.policies.ensemble import PolicyEnsemble
 
 
 @pytest.mark.parametrize("filename", glob.glob(
@@ -18,3 +22,26 @@ def test_load_config(filename):
     assert len(loaded) == 2
     assert isinstance(loaded[0], MemoizationPolicy)
     assert isinstance(loaded[1], ExamplePolicy)
+
+
+def test_ensemble_from_dict():
+    ensemble_dict = {'policies': [
+            {'epochs': 50, 'name': 'KerasPolicy', 'featurizer': [
+                {'max_history': 5, 'name': 'MaxHistoryTrackerFeaturizer',
+                 'state_featurizer': [
+                 	{'name': 'BinarySingleStateFeaturizer'}]}]},
+            {'max_history': 5, 'name': 'MemoizationPolicy'},
+            {'core_threshold': 0.7, 'name': 'FallbackPolicy',
+             'nlu_threshold': 0.7,
+             'fallback_action_name': 'action_default_fallback'},
+            {'name': 'FormPolicy'}]}
+
+    ensemble = PolicyEnsemble.from_dict(ensemble_dict)
+    assert len(ensemble) == 4
+    assert any([isinstance(p, MemoizationPolicy) for p in ensemble])
+    assert any([isinstance(p, KerasPolicy) for p in ensemble])
+    assert any([isinstance(p, FallbackPolicy) for p in ensemble])
+    assert any([isinstance(p, FormPolicy) for p in ensemble])
+
+
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,7 +29,7 @@ def test_ensemble_from_dict():
             {'epochs': 50, 'name': 'KerasPolicy', 'featurizer': [
                 {'max_history': 5, 'name': 'MaxHistoryTrackerFeaturizer',
                  'state_featurizer': [
-                 	{'name': 'BinarySingleStateFeaturizer'}]}]},
+                     {'name': 'BinarySingleStateFeaturizer'}]}]},
             {'max_history': 5, 'name': 'MemoizationPolicy'},
             {'core_threshold': 0.7, 'name': 'FallbackPolicy',
              'nlu_threshold': 0.7,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,3 @@ def test_ensemble_from_dict():
     assert any([isinstance(p, KerasPolicy) for p in ensemble])
     assert any([isinstance(p, FallbackPolicy) for p in ensemble])
     assert any([isinstance(p, FormPolicy) for p in ensemble])
-
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.fallback import FallbackPolicy
 from rasa_core.policies.form_policy import FormPolicy
 from rasa_core.policies.ensemble import PolicyEnsemble
+from rasa_core.featurizers import BinarySingleStateFeaturizer, MaxHistoryTrackerFeaturizer
 
 
 @pytest.mark.parametrize("filename", glob.glob(
@@ -25,6 +26,25 @@ def test_load_config(filename):
 
 
 def test_ensemble_from_dict():
+    def check_memoization(p):
+        assert p.max_history == 5
+
+    def check_keras(p):
+        featurizer = p.featurizer
+        state_featurizer = featurizer.state_featurizer
+        # Assert policy
+        assert p.epochs == 50
+        # Assert featurizer
+        assert isinstance(featurizer, MaxHistoryTrackerFeaturizer)
+        assert featurizer.max_history == 5
+        # Assert state_featurizer
+        assert isinstance(state_featurizer, BinarySingleStateFeaturizer)
+
+    def check_fallback(p):
+        assert p.fallback_action_name == 'action_default_fallback'
+        assert p.nlu_threshold == 0.7
+        assert p.core_threshold == 0.7
+
     ensemble_dict = {'policies': [
             {'epochs': 50, 'name': 'KerasPolicy', 'featurizer': [
                 {'max_history': 5, 'name': 'MaxHistoryTrackerFeaturizer',
@@ -35,10 +55,23 @@ def test_ensemble_from_dict():
              'nlu_threshold': 0.7,
              'fallback_action_name': 'action_default_fallback'},
             {'name': 'FormPolicy'}]}
-
     ensemble = PolicyEnsemble.from_dict(ensemble_dict)
+
+    # Check if all policies are present
     assert len(ensemble) == 4
-    assert any([isinstance(p, MemoizationPolicy) for p in ensemble])
+    # MemoizationPolicy is parent of FormPolicy
+    assert any([isinstance(p, MemoizationPolicy) and
+        not isinstance(p, FormPolicy) for p in ensemble])
     assert any([isinstance(p, KerasPolicy) for p in ensemble])
     assert any([isinstance(p, FallbackPolicy) for p in ensemble])
     assert any([isinstance(p, FormPolicy) for p in ensemble])
+
+    # Verify policy configurations
+    for policy in ensemble:
+        if isinstance(policy, MemoizationPolicy) \
+        and not isinstance(policy, FormPolicy):
+            check_memoization(policy)
+        elif isinstance(policy, KerasPolicy):
+            check_keras(policy)
+        elif isinstance(policy, FallbackPolicy):
+            check_fallback(policy)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,7 @@ from rasa_core.featurizers import BinarySingleStateFeaturizer, \
 
 
 @pytest.mark.parametrize("filename", glob.glob(
-            "data/test_config/example_config.yaml"))
+    "data/test_config/example_config.yaml"))
 def test_load_config(filename):
     loaded = load(filename)
     assert len(loaded) == 2
@@ -61,7 +61,7 @@ def test_ensemble_from_dict():
     # Check if all policies are present
     assert len(ensemble) == 4
     # MemoizationPolicy is parent of FormPolicy
-    assert any([isinstance(p, MemoizationPolicy) and \
+    assert any([isinstance(p, MemoizationPolicy) and
                 not isinstance(p, FormPolicy) for p in ensemble])
     assert any([isinstance(p, KerasPolicy) for p in ensemble])
     assert any([isinstance(p, FallbackPolicy) for p in ensemble])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,8 @@ from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.fallback import FallbackPolicy
 from rasa_core.policies.form_policy import FormPolicy
 from rasa_core.policies.ensemble import PolicyEnsemble
-from rasa_core.featurizers import BinarySingleStateFeaturizer, MaxHistoryTrackerFeaturizer
+from rasa_core.featurizers import BinarySingleStateFeaturizer, 
+    MaxHistoryTrackerFeaturizer
 
 
 @pytest.mark.parametrize("filename", glob.glob(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ from rasa_core.policies.keras_policy import KerasPolicy
 from rasa_core.policies.fallback import FallbackPolicy
 from rasa_core.policies.form_policy import FormPolicy
 from rasa_core.policies.ensemble import PolicyEnsemble
-from rasa_core.featurizers import BinarySingleStateFeaturizer, 
+from rasa_core.featurizers import BinarySingleStateFeaturizer, \
     MaxHistoryTrackerFeaturizer
 
 


### PR DESCRIPTION
- get_featurizer_from_dict and get_state_featurizer_from_dict are called like classmethods in from_dict, but classmethod decorator is missing.
- Instead of get_state_featurizer_from_dict, get_featurizer_from_dict is called twice

**Proposed changes**:
- Added `@classmethod` to both methods
- Changed get_featurizer_from_dict to get_state_featurizer_from_dict when state featurizer is created

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
