### PR TITLE
Changed tracker_store param 'user' to 'username' in docs

### DIFF
--- a/docs/docker_walkthrough.rst
+++ b/docs/docker_walkthrough.rst
@@ -654,7 +654,7 @@ configuration ``config/endpoints.yml``:
   tracker_store:
     store_type: mongod
     url: mongodb://mongo:27017
-    user: rasa
+    username: rasa
     password: example
 
 Then start all components with ``docker-compose up``.


### PR DESCRIPTION
**Proposed changes**:
- The username parameter for tracker_store should be 'username' not 'user' as discussed here (#1332)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
