### PR TITLE
fix an error during interactive training with actions using utter_cus…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changed
 
 Fixed
 -----
+- fix error during interactive learning which was caused by actions which
+  dispatched messages using ``dispatcher.utter_custom_message``
 
 [0.12.1] - 2018-11-11
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -175,7 +175,7 @@ class OutputChannel(object):
                 title=element.get('title', ''),
                 subtitle=element.get('subtitle', ''))
             self.send_text_with_buttons(
-                recipient_id, element_msg, element['buttons'])
+                recipient_id, element_msg, element.get('buttons', []))
 
 
 class CollectingOutputChannel(OutputChannel):

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -239,10 +239,8 @@ def format_bot_output(
 ) -> Text:
     """Format a bot response to be displayed in the history table."""
 
-    if "text" in message:
-        output = message.get("text")
-    else:
-        output = ""
+    output = message.get("text", "")
+    output = "" if output is None else output
 
     # Append all additional items
     data = message.get("data", {})
@@ -256,6 +254,12 @@ def format_bot_output(
         for idx, button in enumerate(data.get("buttons")):
             button_str = button_to_string(button, idx)
             output += "\n" + button_str
+
+    if data.get("elements"):
+        for element in data.get('elements'):
+            import json
+            output += "\nElements: "
+            output += "\n" + json.dumps(element)
     return output
 
 

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -239,7 +239,7 @@ def format_bot_output(
 ) -> Text:
     """Format a bot response to be displayed in the history table."""
 
-    output = message.get("text", "")
+    output = message.get("text") or ""
     output = "" if output is None else output
 
     # Append all additional items

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -240,7 +240,6 @@ def format_bot_output(
     """Format a bot response to be displayed in the history table."""
 
     output = message.get("text") or ""
-    output = "" if output is None else output
 
     # Append all additional items
     data = message.get("data", {})

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -681,3 +681,15 @@ def test_int_sender_id_in_user_message():
     message = UserMessage("A text", sender_id=1234567890)
 
     assert message.sender_id == "1234567890"
+
+
+def test_send_custom_messages_without_buttons():
+    from rasa_core.channels.channel import OutputChannel
+
+    def test_message(sender, message):
+        assert sender == 'user'
+        assert message == 'a : b'
+
+    channel = OutputChannel()
+    channel.send_text_message = test_message
+    channel.send_custom_message("user", [{'title': 'a', 'subtitle': 'b'}])

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -205,3 +205,25 @@ def test_undo_latest_msg(mock_endpoint):
     replaced_evts = json.loads(b)
     assert len(replaced_evts) == 6
     assert replaced_evts == evts[:6]
+
+
+def test_utter_custom_message():
+    test_event = """
+      {
+      "data": {
+        "attachment": null,
+        "buttons": null,
+        "elements": [
+          {
+            "a": "b"
+          }
+        ]
+      },
+      "event": "bot",
+      "text": null,
+      "timestamp": 1542649219.331037
+    }
+    """
+    actual = interactive._chat_history_table([json.loads(test_event)])
+
+    assert json.dumps({'a': 'b'}) in actual


### PR DESCRIPTION
**Issue**:
- https://github.com/RasaHQ/rasa_core/issues/1080

**Proposed changes**:
- always have empty output string even if there is no text in bots message
- safe access of buttons key in channels 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- ~[ ] updated the documentation~
- [x] updated the changelog
