### PR TITLE
Changing button / element representation to allow for customized buttons in cmdline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,17 @@ This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 
 Added
 -----
-
 - added scipy dependency
+- added element representation for command-line output
+
+Changed
+-------
+- improved button representation for custom buttons in command-line
 
 Removed
 -------
 - removed keras dependency, since keras_policy uses tf.keras
+
 
 [0.12.2] - 2018-11-20
 ^^^^^^^^^^^^^^^^^^^^^
@@ -23,6 +28,7 @@ Fixed
 -----
 - argument handling on evaluate script
 - added basic sanitization during visualization
+
 
 [0.12.1] - 2018-11-11
 ^^^^^^^^^^^^^^^^^^^^^

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -67,10 +67,32 @@ def register(input_channels,  # type: List[InputChannel]
 
 def button_to_string(button, idx=0):
     """Create a string representation of a button."""
-    return "{idx}: {title} ({val})".format(
-            idx=idx + 1,
-            title=button.get('title', ''),
-            val=button.get('payload', ''))
+
+    title = button.get('title', '')
+    payload = button.get('payload', '')
+    if payload:
+        payload = " ({})".format(payload)
+
+    button_string = "{idx}: {title}{payload} {button}".format(
+                     idx=idx + 1,
+                     title=title,
+                     payload=payload,
+                     button=json.dumps(button))
+
+    return button_string
+
+
+def element_to_string(element, idx=0):
+    """Create a string representation of an element."""
+
+    title = element.get('title', '')
+
+    element_string = "{idx}: {title} {element}".format(
+                      idx=idx,
+                      title=title,
+                      element=json.dumps(element))
+
+    return element_string
 
 
 class InputChannel(object):

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -68,16 +68,19 @@ def register(input_channels,  # type: List[InputChannel]
 def button_to_string(button, idx=0):
     """Create a string representation of a button."""
 
-    title = button.get('title', '')
-    payload = button.get('payload', '')
+    title = button.pop('title', '')
+    payload = button.pop('payload', '')
     if payload:
-        payload = " ({})".format(payload)
+        payload = "({})".format(payload)
 
-    button_string = "{idx}: {title}{payload} {button}".format(
+    button_string = "{idx}: {title} {payload}".format(
                      idx=idx + 1,
                      title=title,
-                     payload=payload,
-                     button=json.dumps(button, sort_keys=True))
+                     payload=payload)
+
+    if button:
+        button_string += " - {button}".format(
+            button=json.dumps(button, sort_keys=True))
 
     return button_string
 
@@ -85,9 +88,9 @@ def button_to_string(button, idx=0):
 def element_to_string(element, idx=0):
     """Create a string representation of an element."""
 
-    title = element.get('title', '')
+    title = element.pop('title', '')
 
-    element_string = "{idx}: {title} {element}".format(
+    element_string = "{idx}: {title} - {element}".format(
                       idx=idx + 1,
                       title=title,
                       element=json.dumps(element, sort_keys=True))

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -69,18 +69,23 @@ def button_to_string(button, idx=0):
     """Create a string representation of a button."""
 
     title = button.pop('title', '')
-    payload = button.pop('payload', '')
-    if payload:
-        payload = "({})".format(payload)
 
-    button_string = "{idx}: {title} {payload}".format(
-                     idx=idx + 1,
-                     title=title,
-                     payload=payload)
+    if 'payload' in button:
+        payload = " ({})".format(button.pop('payload'))
+    else:
+        payload = ""
 
+    # if there are any additional attributes, we append them to the output
     if button:
-        button_string += " - {button}".format(
-            button=json.dumps(button, sort_keys=True))
+        details = " - {}".format(json.dumps(button, sort_keys=True))
+    else:
+        details = ""
+
+    button_string = "{idx}: {title}{payload}{details}".format(
+        idx=idx + 1,
+        title=title,
+        payload=payload,
+        details=details)
 
     return button_string
 
@@ -91,9 +96,9 @@ def element_to_string(element, idx=0):
     title = element.pop('title', '')
 
     element_string = "{idx}: {title} - {element}".format(
-                      idx=idx + 1,
-                      title=title,
-                      element=json.dumps(element, sort_keys=True))
+        idx=idx + 1,
+        title=title,
+        element=json.dumps(element, sort_keys=True))
 
     return element_string
 

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -77,7 +77,7 @@ def button_to_string(button, idx=0):
                      idx=idx + 1,
                      title=title,
                      payload=payload,
-                     button=json.dumps(button))
+                     button=json.dumps(button, sort_keys=True))
 
     return button_string
 
@@ -90,7 +90,7 @@ def element_to_string(element, idx=0):
     element_string = "{idx}: {title} {element}".format(
                       idx=idx + 1,
                       title=title,
-                      element=json.dumps(element))
+                      element=json.dumps(element, sort_keys=True))
 
     return element_string
 

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -88,7 +88,7 @@ def element_to_string(element, idx=0):
     title = element.get('title', '')
 
     element_string = "{idx}: {title} {element}".format(
-                      idx=idx,
+                      idx=idx + 1,
                       title=title,
                       element=json.dumps(element))
 

--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -11,7 +11,8 @@ import six
 
 from rasa_core import utils
 from rasa_core.channels import UserMessage
-from rasa_core.channels.channel import button_to_string, RestInput
+from rasa_core.channels.channel import button_to_string, element_to_string,\
+    RestInput
 from rasa_core.constants import DEFAULT_SERVER_URL
 from rasa_core.interpreter import INTENT_MESSAGE_PREFIX
 
@@ -28,8 +29,13 @@ def print_bot_output(message, color=utils.bcolors.OKBLUE):
 
     if "buttons" in message:
         for idx, button in enumerate(message.get("buttons")):
-            button_str = button_to_string(button, idx)
+            button_str = "Buttons:\n" + button_to_string(button, idx)
             utils.print_color(button_str, color)
+
+    if "elements" in message:
+        for idx, element in enumerate(message.get("elements")):
+            element_str = "Elements:\n" + element_to_string(element, idx)
+            utils.print_color(element_str, color)
 
 
 def get_cmd_input():

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -21,7 +21,7 @@ from rasa_core import utils, server, events, constants
 from rasa_core.actions.action import ACTION_LISTEN_NAME, default_action_names
 from rasa_core.agent import Agent
 from rasa_core.channels import UserMessage
-from rasa_core.channels.channel import button_to_string
+from rasa_core.channels.channel import button_to_string, element_to_string
 from rasa_core.constants import (
     DEFAULT_SERVER_PORT, DEFAULT_SERVER_URL, REQUESTED_SLOT)
 from rasa_core.domain import Domain

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -243,12 +243,13 @@ def format_bot_output(message):
     # type: (Dict[Text, Any]) -> Text
     """Format a bot response to be displayed in the history table."""
 
-    if "text" in message:
-        output = message.get("text")
-    else:
-        output = ""
+    output = ""
 
-    # Append all additional items
+    # First, add text to output
+    if message.get("text"):
+        output += message.get("text")
+
+    # Then, append all additional items
     data = message.get("data", {})
     if data.get("image"):
         output += "\nImage: " + data.get("image")

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -257,9 +257,16 @@ def format_bot_output(message):
         output += "\nAttachment: " + data.get("attachment")
 
     if data.get("buttons"):
+        output += "\nButtons:"
         for idx, button in enumerate(data.get("buttons")):
             button_str = button_to_string(button, idx)
             output += "\n" + button_str
+
+    if data.get("elements"):
+        output += "\nElements:"
+        for idx, element in enumerate(data.get("elements")):
+            element_str = element_to_string(element, idx)
+            output += "\n" + element_str
     return output
 
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -69,13 +69,15 @@ def test_bot_output_format():
                          "Image: http://example.com/myimage.png\n"
                          "Attachment: My Attachment\n"
                          "Buttons:\n"
-                         "1: yes (/yes) {\"payload\": \"/yes\", \"title\": \"yes\"}\n"
-                         "2: no (/no) {\"payload\": \"/no\", \"title\": \"no\"}\n"
+                         "1: yes (/yes) {\"payload\": \"/yes\", "
+                         "\"title\": \"yes\"}\n"
+                         "2: no (/no) {\"payload\": \"/no\", "
+                         "\"title\": \"no\"}\n"
                          "Elements:\n"
-                         "0: element1 {\"buttons\": [{\"payload\": \"/button1\", "
-                         "\"title\": \"button1\"}], \"title\": \"element1\"}\n"
-                         "1: element2 {\"buttons\": [{\"payload\": \"/button2\", "
-                         "\"title\": \"button2\"}], \"title\": \"element2\"}")
+                         "1: element1 {\"buttons\": [{\"payload\": \"/button1\""
+                         ", \"title\": \"button1\"}], \"title\": \"element1\"}\n"
+                         "2: element2 {\"buttons\": [{\"payload\": \"/button2\""
+                         ", \"title\": \"button2\"}], \"title\": \"element2\"}")
 
 
 def test_latest_user_message():

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -56,7 +56,7 @@ def test_bot_output_format():
             "attachment": "My Attachment",
             "buttons": [
                 {"title": "yes", "payload": "/yes"},
-                {"title": "no", "payload": "/no"}],
+                {"title": "no", "payload": "/no", "extra": "extra"}],
             "elements": [
                 {"title": "element1", "buttons": [
                     {"title": "button1", "payload": "/button1"}]},
@@ -69,17 +69,15 @@ def test_bot_output_format():
                          "Image: http://example.com/myimage.png\n"
                          "Attachment: My Attachment\n"
                          "Buttons:\n"
-                         "1: yes (/yes) {\"payload\": \"/yes\", "
-                         "\"title\": \"yes\"}\n"
-                         "2: no (/no) {\"payload\": \"/no\", "
-                         "\"title\": \"no\"}\n"
+                         "1: yes (/yes)\n"
+                         "2: no (/no) - {\"extra\": \"extra\"}\n"
                          "Elements:\n"
-                         "1: element1 {\"buttons\": "
+                         "1: element1 - {\"buttons\": "
                          "[{\"payload\": \"/button1\", \"title\": \"button1\"}"
-                         "], \"title\": \"element1\"}\n"
-                         "2: element2 {\"buttons\": "
+                         "]}\n"
+                         "2: element2 - {\"buttons\": "
                          "[{\"payload\": \"/button2\", \"title\": \"button2\"}"
-                         "], \"title\": \"element2\"}")
+                         "]}")
 
 
 def test_latest_user_message():

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -74,10 +74,12 @@ def test_bot_output_format():
                          "2: no (/no) {\"payload\": \"/no\", "
                          "\"title\": \"no\"}\n"
                          "Elements:\n"
-                         "1: element1 {\"buttons\": [{\"payload\": \"/button1\""
-                         ", \"title\": \"button1\"}], \"title\": \"element1\"}\n"
-                         "2: element2 {\"buttons\": [{\"payload\": \"/button2\""
-                         ", \"title\": \"button2\"}], \"title\": \"element2\"}")
+                         "1: element1 {\"buttons\": "
+                         "[{\"payload\": \"/button1\", \"title\": \"button1\"}"
+                         "], \"title\": \"element1\"}\n"
+                         "2: element2 {\"buttons\": "
+                         "[{\"payload\": \"/button2\", \"title\": \"button2\"}"
+                         "], \"title\": \"element2\"}")
 
 
 def test_latest_user_message():

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -56,15 +56,26 @@ def test_bot_output_format():
             "attachment": "My Attachment",
             "buttons": [
                 {"title": "yes", "payload": "/yes"},
-                {"title": "no", "payload": "/no"}]
+                {"title": "no", "payload": "/no"}],
+            "elements": [
+                {"title": "element1", "buttons": [
+                    {"title": "button1", "payload": "/button1"}]},
+                {"title": "element2", "buttons": [
+                    {"title": "button2", "payload": "/button2"}]}]
         }
     }
     formatted = interactive.format_bot_output(message)
     assert formatted == ("Hello!\n"
                          "Image: http://example.com/myimage.png\n"
                          "Attachment: My Attachment\n"
-                         "1: yes (/yes)\n"
-                         "2: no (/no)")
+                         "Buttons:\n"
+                         "1: yes (/yes) {\"payload\": \"/yes\", \"title\": \"yes\"}\n"
+                         "2: no (/no) {\"payload\": \"/no\", \"title\": \"no\"}\n"
+                         "Elements:\n"
+                         "0: element1 {\"buttons\": [{\"payload\": \"/button1\", "
+                         "\"title\": \"button1\"}], \"title\": \"element1\"}\n"
+                         "1: element2 {\"buttons\": [{\"payload\": \"/button2\", "
+                         "\"title\": \"button2\"}], \"title\": \"element2\"}")
 
 
 def test_latest_user_message():


### PR DESCRIPTION
@akelad @tmbo : Sorry, I somehow messed up the other [PR](https://github.com/RasaHQ/rasa_core/pull/1344) request such that it got closed and cannot reopen it again. Summarizing the key issues again here: 

Custom buttons and elements couldn't be displayed in interactive learning and console channel output.

**Proposed changes**:
- Adjusted button to string representation to add custom attributes as JSON object after current string
- Added element to string representation for custom messages accordingly
- Adjusted test cases
- Added element to string representations to console and interactive learning output 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
