### PR TITLE
Randomized initial sender_id in interactive.py to allow fresh training sessions upon start

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Added
 
 - added scipy dependency
 
+Changed
+-------
+- randomized initial sender_id during interactive training to avoid loading
+  previous sessions from persistent tracker stores
+
 Removed
 -------
 - removed keras dependency, since keras_policy uses tf.keras

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -1321,7 +1321,8 @@ def _start_interactive_learning_io(endpoint, stories, on_finish,
                    "on_finish": on_finish,
                    "stories": stories,
                    "finetune": finetune,
-                   "skip_visualization": skip_visualization})
+                   "skip_visualization": skip_visualization,
+                   "sender_id": uuid.uuid4().hex})
     p.setDaemon(True)
     p.start()
 


### PR DESCRIPTION
According to #1339, in-memory tracker stores load previous sessions during interactive learning.

**Proposed changes**:
- Make initial sender_id random

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
