### PR TITLE
FileNotFoundError does not exist in Python 2.x

### DIFF
--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -46,6 +46,11 @@ from rasa_nlu.training_data.formats import MarkdownWriter, MarkdownReader
 from rasa_nlu.training_data.loading import load_data, _guess_format
 from rasa_nlu.training_data.message import Message
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 # WARNING: This command line UI is using an external library
 # communicating with the shell - these functions are hard to test
 # automatically. If you change anything in here, please make sure to


### PR DESCRIPTION
Added a quick fix for FileNotFoundError handling in Python 2.x

**Proposed changes**:
- Overwriting FileNotFoundError with IOError for Python 2.x

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
