### PR TITLE
In `format_bot_output`, consider case where data key is present on dict, but None

### DIFF
--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -241,8 +241,11 @@ def format_bot_output(
 
     output = message.get("text") or ""
 
-    # Append all additional items
+    # Append all additional items if data is not None
     data = message.get("data", {})
+    if not data:
+        return output
+
     if data.get("image"):
         output += "\nImage: " + data.get("image")
 


### PR DESCRIPTION
When [passing an event](https://github.com/RasaHQ/rasa_core/blob/0.12.2/rasa_core/training/interactive.py#L522) like BotUttered("only a text message") to format_bot_output this will throw as [the dict being created](https://github.com/RasaHQ/rasa_core_sdk/blob/47106d959767148d15b328a3a38a95cd697e0616/rasa_core_sdk/events.py#L26-L33) will contain a data key, but its value is None. This requires an additional check for this case before proceeding as `get` might as well return `None`.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
