### PR TITLE
Tracker metadata

### DIFF
--- a/data/test_dialogues/enter_name.json
+++ b/data/test_dialogues/enter_name.json
@@ -62,5 +62,6 @@
       "unpredictable": false
     }
   ],
-  "name": "enter_name"
+  "name": "enter_name",
+  "metadata": null
 }

--- a/data/test_dialogues/greet.json
+++ b/data/test_dialogues/greet.json
@@ -24,5 +24,6 @@
       "unpredictable": false
     }
   ],
-  "name": "hello_world"
+  "name": "hello_world",
+  "metadata": null
 }

--- a/data/test_dialogues/greet_2x.json
+++ b/data/test_dialogues/greet_2x.json
@@ -46,5 +46,6 @@
       "unpredictable": false
     }
   ],
-  "name": "hello_world_2x"
+  "name": "hello_world_2x",
+  "metadata": null
 }

--- a/data/test_dialogues/inform_no_change.json
+++ b/data/test_dialogues/inform_no_change.json
@@ -1,6 +1,7 @@
 {
   "py/object": "rasa_core.conversation.Dialogue",
   "name": "inform_but_no_change_wanted",
+  "metadata": null,
   "events": [
     {
       "py/object": "rasa_core.events.UserUttered",

--- a/data/test_dialogues/nlu_dialogue.json
+++ b/data/test_dialogues/nlu_dialogue.json
@@ -31,5 +31,6 @@
       "unpredictable": false
     }
   ],
-  "name": "nlu dialogue"
+  "name": "nlu dialogue",
+  "metadata": null
 }

--- a/data/test_trackers/tracker_moodbot.json
+++ b/data/test_trackers/tracker_moodbot.json
@@ -22,6 +22,7 @@
     ]
   },
   "sender_id": "mysender",
+  "metadata": null,
   "latest_action_name": "action_listen",
   "active_form": {},
   "paused": false,

--- a/rasa_core/conversation.py
+++ b/rasa_core/conversation.py
@@ -1,6 +1,6 @@
+import json
 import typing
-from typing import List
-from typing import Text
+from typing import List, Text, Optional, Any, Dict
 
 if typing.TYPE_CHECKING:
     from rasa_core.events import Event
@@ -9,15 +9,18 @@ if typing.TYPE_CHECKING:
 class Dialogue(object):
     """A dialogue comprises a list of Turn objects"""
 
-    def __init__(self, name: Text, events: List['Event']) -> None:
+    def __init__(self, name: Text, events: List['Event'],
+                 metadata: Optional[Dict[Text, Any]] = None) -> None:
         # This function initialises the dialogue with
         # the dialogue name and the event list.
         self.name = name
         self.events = events
+        self.metadata = metadata
 
     def __str__(self):
         # type: () -> Text
 
         # This function returns the dialogue and turns.
-        return "Dialogue with name '{}' and turns:\n{}".format(
-            self.name, "\n\n".join(["\t{}".format(t) for t in self.events]))
+        return "Dialogue with name '{}', metadata '{}' and turns:\n{}".format(
+            self.name, json.dumps(self.metadata),
+            "\n\n".join(["\t{}".format(t) for t in self.events]))

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -209,9 +209,9 @@ class MessageProcessor(object):
                                                  reminder_event) or not
                 self._is_reminder_still_valid(tracker, reminder_event)):
             logger.debug("Canceled reminder because it is outdated. "
-                         "(event: {} id: {})".format(
-                reminder_event.action_name,
-                reminder_event.name))
+                         "(event: {} id: {})"
+                         "".format(reminder_event.action_name,
+                                   reminder_event.name))
         else:
             # necessary for proper featurization, otherwise the previous
             # unrelated message would influence featurization

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import zipfile
 from functools import wraps
+from json import JSONDecodeError
 from typing import List, Text, Optional, Union, Callable, Any
 
 from flask import Flask, request, abort, Response, jsonify, json
@@ -316,8 +317,15 @@ def create_app(agent,
 
         verbosity = event_verbosity_parameter(default_verbosity)
 
+        try:
+            request_params = request_parameters()
+            metadata = json.loads(request_params["metadata"])
+        except (KeyError, TypeError, JSONDecodeError):
+            metadata = None
+
         # retrieve tracker and set to requested state
-        tracker = agent.tracker_store.get_or_create_tracker(sender_id)
+        tracker = agent.tracker_store.get_or_create_tracker(sender_id,
+                                                            metadata)
         if not tracker:
             return error(503,
                          "NoDomain",

--- a/rasa_core/tracker_store.py
+++ b/rasa_core/tracker_store.py
@@ -193,7 +193,7 @@ class RedisTrackerStore(TrackerStore):
                  ) -> Optional[DialogueStateTracker]:
         stored = self.red.get(sender_id)
         if stored is not None and self._metadata_matches(stored, metadata):
-            return stored
+            return self.deserialise_tracker(sender_id, stored)
 
         return None
 

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -1,9 +1,8 @@
-import typing
-from collections import deque
-
 import copy
 import io
 import logging
+import typing
+from collections import deque
 from enum import Enum
 from typing import Generator, Dict, Text, Any, Optional, Iterator
 from typing import List
@@ -73,7 +72,8 @@ class DialogueStateTracker(object):
         return tracker
 
     def __init__(self, sender_id, slots,
-                 max_event_history=None):
+                 max_event_history=None,
+                 metadata: Optional[Dict[Text, Any]] = None):
         """Initialize the tracker.
 
         A set of events can be stored externally, and we will run through all
@@ -104,6 +104,7 @@ class DialogueStateTracker(object):
         self.latest_bot_utterance = None
         self._reset()
         self.active_form = {}
+        self.metadata = metadata
 
     ###
     # Public tracker interface
@@ -136,7 +137,8 @@ class DialogueStateTracker(object):
             "events": evts,
             "latest_input_channel": self.get_latest_input_channel(),
             "active_form": self.active_form,
-            "latest_action_name": self.latest_action_name
+            "latest_action_name": self.latest_action_name,
+            "metadata": self.metadata
         }
 
     def past_states(self, domain: 'Domain') -> deque:
@@ -390,7 +392,7 @@ class DialogueStateTracker(object):
         This can be serialised and later used to recover the state
         of this tracker exactly."""
 
-        return Dialogue(self.sender_id, list(self.events))
+        return Dialogue(self.sender_id, list(self.events), self.metadata)
 
     def update(self, event: Event) -> None:
         """Modify the state of the tracker according to an ``Event``. """

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -112,7 +112,8 @@ def test_remote_action_runs(default_dispatcher_collecting, default_domain):
             'followup_action': 'action_listen',
             'slots': {'name': None},
             'events': [],
-            'latest_input_channel': None
+            'latest_input_channel': None,
+            'metadata': None
         }
     }
 
@@ -167,7 +168,8 @@ def test_remote_action_logs_events(default_dispatcher_collecting,
             'latest_event_time': None,
             'slots': {'name': None},
             'events': [],
-            'latest_input_channel': None
+            'latest_input_channel': None,
+            'metadata': None
         }
     }
 


### PR DESCRIPTION
**Proposed changes**:
- add metadata to `DialogueStateTracker` and `Dialogue`
- metadata can be used to request trackers in addition to `sender_id`

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
