### PR TITLE
Fix output of training with --debug_plots

### DIFF
--- a/rasa_core/train.py
+++ b/rasa_core/train.py
@@ -154,7 +154,7 @@ def add_general_args(parser):
         action='store_true',
         help="If enabled, will create plots showing checkpoints "
              "and their connections between story blocks in a  "
-             "file called `story_blocks_connections.pdf`.")
+             "file called `story_blocks_connections.html`.")
 
     utils.add_logging_option_arguments(parser)
 

--- a/rasa_core/training/generator.py
+++ b/rasa_core/training/generator.py
@@ -151,7 +151,7 @@ class TrainingDataGenerator(object):
 
         self.story_graph = story_graph.with_cycles_removed()
         if debug_plots:
-            self.story_graph.visualize('story_blocks_connections.pdf')
+            self.story_graph.visualize('story_blocks_connections.html')
 
         self.domain = domain
 

--- a/rasa_core/training/structures.py
+++ b/rasa_core/training/structures.py
@@ -708,7 +708,7 @@ class StoryGraph(object):
                            label=utils.cap_length(step.block_name),
                            style="filled",
                            fillcolor="lightblue",
-                           shape="box")
+                           shape="rect")
 
             for c in step.start_checkpoints:
                 ensure_checkpoint_is_drawn(c)


### PR DESCRIPTION
This picks up #1390. I tried using `--debug_plots` but ran into two issues:

- a pdf file is exported, but it seems to be a HTML document
- when opening this document in a browser it will not display anything, throwing:

```
dagre-d3.min.js:26 Uncaught TypeError: shape is not a function
    at SVGGElement.<anonymous> (dagre-d3.min.js:26)
    at Selection.selection_each [as each] (d3.v4.js:1185)
    at createNodes (dagre-d3.min.js:26)
    at fn (dagre-d3.min.js:90)
    at Selection.selection_call [as call] (d3.v4.js:1149)
    at drawGraph (story_blocks_connections.html:114)
    at story_blocks_connections.html:916
```

I managed to fix both issues and can use the patched version as expected.

**Proposed changes**:
- Change the file extension of `debug_plots` so that it matches the output (it's a HTML file, not a PDF)
- Use a shape type supported by `dagre-d3`, see https://github.com/dagrejs/dagre-d3/issues/131

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
