### PR TITLE
Do not override custom button type if provided (#1416)

### DIFF
--- a/rasa_core/channels/facebook.py
+++ b/rasa_core/channels/facebook.py
@@ -183,9 +183,10 @@ class MessengerBot(OutputChannel):
 
     @staticmethod
     def _add_postback_info(buttons: List[Dict[Text, Any]]) -> None:
-        """Set the button type to postback for all buttons. Happens in place."""
+        """Set the button type to postback (if not provided) for all buttons. Happens in place."""
         for button in buttons:
-            button['type'] = "postback"
+            if 'type' not in button:
+               button['type'] = "postback"
 
     @staticmethod
     def _recipient_json(recipient_id: Text) -> Dict[Text, Dict[Text, Text]]:

--- a/rasa_core/channels/facebook.py
+++ b/rasa_core/channels/facebook.py
@@ -186,7 +186,7 @@ class MessengerBot(OutputChannel):
         """Make sure every button has a type. Modifications happen in place."""
         for button in buttons:
             if 'type' not in button:
-               button['type'] = "postback"
+                button['type'] = "postback"
 
     @staticmethod
     def _recipient_json(recipient_id: Text) -> Dict[Text, Dict[Text, Text]]:

--- a/rasa_core/channels/facebook.py
+++ b/rasa_core/channels/facebook.py
@@ -183,7 +183,7 @@ class MessengerBot(OutputChannel):
 
     @staticmethod
     def _add_postback_info(buttons: List[Dict[Text, Any]]) -> None:
-        """Set the button type to postback (if not provided) for all buttons. Happens in place."""
+        """Make sure every button has a type. Modifications happen in place."""
         for button in buttons:
             if 'type' not in button:
                button['type'] = "postback"


### PR DESCRIPTION
**Proposed changes**:
- Currently, Rasa overrides custom buttons to be always of the type "postback" even if the type is different and being provided. Changed this behavior to allow other button types (web_url etc.)
- fixes #1417 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
