### PR TITLE
Add documentation for Policy.load and Policy.persist

### DIFF
--- a/docs/api/policy.rst
+++ b/docs/api/policy.rst
@@ -13,5 +13,9 @@ A Policy decides what action to take at every step in a dialogue
 
    .. automethod:: predict_action_probabilities
 
+   .. automethod:: load
+
+   .. automethod:: persist
+
 
 .. include:: ../feedback.inc


### PR DESCRIPTION
For implementing custom Policy classes

It'd be useful to add these methods to the API documentation - to use Agent.load and Agent.persist with a custom policy, you have to implement these methods in your custom Policy, but this isn't documented anywhere yet

