### PR TITLE
Typo in server.rst docs

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -38,7 +38,7 @@ models with:
 .. code-block:: bash
 
     $ python -m rasa_core.run \
-        --enable_api
+        --enable_api \
         -d models/dialogue \
         -u models/nlu/current \
         -o out.log


### PR DESCRIPTION
Typo in the documentation on page server.rst. The command for running the rasa core had missing backslash.

**Proposed changes**:
- Add backslash

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ x ] updated the documentation
- [ ] updated the changelog
