### PR TITLE
Enabling channel specific utterances

### DIFF
--- a/rasa_core/nlg/template.py
+++ b/rasa_core/nlg/template.py
@@ -26,7 +26,11 @@ class TemplatedNaturalLanguageGenerator(NaturalLanguageGenerator):
                              ) -> Optional[Dict[Text, Any]]:
         """Select random template for the utter action from available ones."""
 
-        if utter_action in self.templates:
+        channel_utter_action = "{}.{}".format(output_channel, utter_action)
+
+        if channel_utter_action in self.templates:
+            return np.random.choice(self.templates[channel_utter_action])
+        elif utter_action in self.templates:
             return np.random.choice(self.templates[utter_action])
         else:
             return None


### PR DESCRIPTION
@tmbo based on our quick discussion [here](https://forum.rasa.com/t/create-different-answers-based-on-channel-that-is-used/2757), I added the option of using a `channel_name` prefix for templates to customize responses based on channel.

With this change one could have the following in the domain.yml

templates:
  - utter_welcome
    - "Welcome to our bot"
  - facebook.utter_welcome
    - "Welcome to our facebook bot"

and could completely customize text, buttons, etc. for every channel, but have the non-prefixed version as default utterance.

Let me know what you think of this option.

**Proposed changes**:
- Before looking up the templates by name as it is done right now, we look for a template called `channel_name.template_name` and return this one if it's available.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
