### PR TITLE
update connectors.rst

### DIFF
--- a/docs/connectors.rst
+++ b/docs/connectors.rst
@@ -234,7 +234,7 @@ you need to supply a ``credentials.yml`` with the following content:
 
    slack:
      slack_token: "xoxb-286425452756-safjasdf7sl38KLls"
-     slack_channel: "@my_channel"
+     slack_channel: "#my_channel" or "@my_app"
 
 
 The endpoint for receiving slack messages is


### PR DESCRIPTION
Updated connectors file to reflect the correct way to pass in slack channel.


**Proposed changes**:
- "#my_channel" or "@my_app"  instead of ==>  "@my_channel"

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
