### PR TITLE
do not allow a user to confirm None intent in interactive learning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 - A support for session persistence mechanism in the ``SocketIOInput``
   compatible with the example SocketIO WebChat + short explanation on
   how session persistence should be implemented in a frontend
-- `TwoStageFallbackPolicy` which asks the user for their affirmation if the NLU
+- ``TwoStageFallbackPolicy`` which asks the user for their affirmation if the NLU
   confidence is low for an intent, for rephrasing the intent if they deny the
   suggested intent, and does finally an ultimate fallback if it does not get
   the intent right
@@ -28,6 +28,8 @@ Removed
 Changed
 -------
 - replaced ``pytest-pep8`` with ``pytest-pycodestyle``
+- if NLU classification returned ``None`` in interactive training,
+  directly ask a user for a correct intent
 
 Fixed
 -----

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -1060,21 +1060,26 @@ def _validate_user_text(latest_message: Dict[Text, Any],
     This assumes the user message is a text message (so NOT `/greet`)."""
 
     parse_data = latest_message.get("parse_data", {})
-    entities = _as_md_message(parse_data)
+    text = _as_md_message(parse_data)
     intent = parse_data.get("intent", {}).get("name")
 
-    q = ("Is the NLU classification for '{}' with intent "
-         "'{}' correct?".format(entities, intent))
+    if intent is None:
+        print("The NLU classification for '{}' returned '{}'"
+              "".format(text, intent))
+        return False
+    else:
+        q = ("Is the NLU classification for '{}' with intent "
+             "'{}' correct?".format(text, intent))
 
-    questions = [
-        {
-            "type": "confirm",
-            "name": "nlu",
-            "message": q,
-        }
-    ]
-    answers = _ask_questions(questions, sender_id, endpoint)
-    return answers["nlu"]
+        questions = [
+            {
+                "type": "confirm",
+                "name": "nlu",
+                "message": q,
+            }
+        ]
+        answers = _ask_questions(questions, sender_id, endpoint)
+        return answers["nlu"]
 
 
 def _validate_nlu(intents: List[Text],


### PR DESCRIPTION
**Proposed changes**:
- if NLU classification returned `None`, directly ask a user for a correct intent
- fixes #1488 
- fixes #1465 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog