### PR TITLE
colored user input on cmdline chat

### DIFF
--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -1,8 +1,9 @@
 # this builtin is needed so we can overwrite in test
-from builtins import input
+import questionary
 
 import json
 import requests
+from prompt_toolkit.styles import Style
 
 from rasa_core import utils
 from rasa_core.channels import UserMessage
@@ -34,7 +35,8 @@ def print_bot_output(message, color=utils.bcolors.OKBLUE):
 
 
 def get_cmd_input():
-    return input().strip()
+    return questionary.text("", style=Style([('qmark', '#b373d6'),
+                                             ('', '#b373d6')])).ask().strip()
 
 
 def send_message_receive_block(server_url, auth_token, sender_id, message):


### PR DESCRIPTION
**Proposed changes**:
- fixes #1577

This is how it looks:
<img width="1050" alt="bildschirmfoto 2019-01-16 um 14 32 48" src="https://user-images.githubusercontent.com/1098412/51252306-c529ff80-199b-11e9-912d-37cb878a9940.png">

@JustinaPetr any thoughts on this?

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] updated the changelog
