### PR TITLE
fix printing multiple `Buttons:` in cmd

### DIFF
--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -25,8 +25,7 @@ def print_bot_output(message, color=utils.bcolors.OKBLUE):
     if "buttons" in message:
         utils.print_color("Buttons:", color)
         for idx, button in enumerate(message.get("buttons")):
-            button_str = button_to_string(button, idx)
-            utils.print_color(button_str, color)
+            utils.print_color(button_to_string(button, idx), color)
 
     if "elements" in message:
         for idx, element in enumerate(message.get("elements")):

--- a/rasa_core/channels/console.py
+++ b/rasa_core/channels/console.py
@@ -23,8 +23,9 @@ def print_bot_output(message, color=utils.bcolors.OKBLUE):
         utils.print_color("Attachment: " + message.get("attachment"), color)
 
     if "buttons" in message:
+        utils.print_color("Buttons:", color)
         for idx, button in enumerate(message.get("buttons")):
-            button_str = "Buttons:\n" + button_to_string(button, idx)
+            button_str = button_to_string(button, idx)
             utils.print_color(button_str, color)
 
     if "elements" in message:


### PR DESCRIPTION
**Proposed changes**:
- fix printing multiple `Buttons:` in cmd

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog