### PR TITLE
Change Memoization confidence value to 1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Changed
   directly ask a user for a correct intent
 - Updated docs for interactive learning to inform users of the
   ``--core`` flag
+- Change memoization policies confidence score to 1.1 to override ML policies
 
 Fixed
 -----

--- a/rasa_core/constants.py
+++ b/rasa_core/constants.py
@@ -16,9 +16,11 @@ DEFAULT_FALLBACK_ACTION = "action_default_fallback"
 
 DEFAULT_REQUEST_TIMEOUT = 60 * 5  # 5 minutes
 
-FALLBACK_SCORE = 1.1
+MEMO_SCORE = 1.1
 
-FORM_SCORE = 1.2
+FALLBACK_SCORE = 1.2
+
+FORM_SCORE = 1.3
 
 REQUESTED_SLOT = 'requested_slot'
 

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -101,7 +101,7 @@ class FallbackPolicy(Policy):
                          "Predicting fallback action: {}"
                          "".format(nlu_confidence, self.nlu_threshold,
                                    self.fallback_action_name))
-            # we set this to 1.1 to make sure fallback overrides
+            # we set this to 1.2 to make sure fallback overrides
             # the memoization policy
             result = self.fallback_scores(domain)
         else:

--- a/rasa_core/policies/memoization.py
+++ b/rasa_core/policies/memoization.py
@@ -14,6 +14,7 @@ from rasa_core.featurizers import (
     TrackerFeaturizer, MaxHistoryTrackerFeaturizer)
 from rasa_core.policies.policy import Policy
 from rasa_core.trackers import DialogueStateTracker
+from rasa_core.constants import MEMO_SCORE
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class MemoizationPolicy(Policy):
 
         This policy is not supposed to be the only policy in an ensemble,
         it is optimized for precision and not recall.
-        It should get a 100% precision because it emits probabilities of 1.0
+        It should get a 100% precision because it emits probabilities of 1.1
         along it's predictions, which makes every mistake fatal as
         no other policy can overrule it.
 
@@ -172,7 +173,7 @@ class MemoizationPolicy(Policy):
             after seeing the tracker.
 
             Returns the list of probabilities for the next actions.
-            If memorized action was found returns 1.0 for its index,
+            If memorized action was found returns 1.1 for its index,
             else returns 0.0 for all actions."""
         result = [0.0] * domain.num_actions
 
@@ -191,9 +192,10 @@ class MemoizationPolicy(Policy):
             if self.USE_NLU_CONFIDENCE_AS_SCORE:
                 # the memoization will use the confidence of NLU on the latest
                 # user message to set the confidence of the action
-                score = tracker.latest_message.intent.get("confidence", 1.0)
+                score = tracker.latest_message.intent.get("confidence",
+                                                          MEMO_SCORE)
             else:
-                score = 1.0
+                score = MEMO_SCORE
 
             result[recalled] = score
         else:

--- a/tests/test_policies.py
+++ b/tests/test_policies.py
@@ -84,7 +84,7 @@ class PolicyTestCollection(object):
         probabilities = trained_policy.predict_action_probabilities(
             tracker, default_domain)
         assert len(probabilities) == default_domain.num_actions
-        assert max(probabilities) <= 1.0
+        assert max(probabilities) <= 1.1
         assert min(probabilities) >= 0.0
 
     def test_persist_and_load_empty_policy(self, tmpdir):


### PR DESCRIPTION
**Proposed changes**:
- Change memoization confidence value to 1.1 so that it actually overrides ML policies when they have a confidence of 1.0 (in fact i feel like it used to be like this, not sure if/when we changed it back to 1.0)
- Increase form policy/fallback policy confidence values so they override the memo policy

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
