### PR TITLE
report core version in remote action call

### DIFF
--- a/rasa_core/actions/action.py
+++ b/rasa_core/actions/action.py
@@ -5,7 +5,7 @@ from typing import List, Text, Optional, Dict, Any
 import requests
 import copy
 
-from rasa_core.version import __version__ as rasa_core_version
+import rasa_core
 from rasa_core import events
 from rasa_core.constants import (
     DOCS_BASE_URL,
@@ -232,7 +232,7 @@ class RemoteAction(Action):
             "sender_id": tracker.sender_id,
             "tracker": tracker_state,
             "domain": domain.as_dict(),
-            "version": rasa_core_version
+            "version": rasa_core.__version__
         }
 
     @staticmethod

--- a/rasa_core/actions/action.py
+++ b/rasa_core/actions/action.py
@@ -5,6 +5,7 @@ from typing import List, Text, Optional, Dict, Any
 import requests
 import copy
 
+from rasa_core.version import __version__ as rasa_core_version
 from rasa_core import events
 from rasa_core.constants import (
     DOCS_BASE_URL,
@@ -230,7 +231,8 @@ class RemoteAction(Action):
             "next_action": self._name,
             "sender_id": tracker.sender_id,
             "tracker": tracker_state,
-            "domain": domain.as_dict()
+            "domain": domain.as_dict(),
+            "version": rasa_core_version
         }
 
     @staticmethod

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from httpretty import httpretty
 
+import rasa_core
 from rasa_core.actions import action
 from rasa_core.actions.action import (
     ActionRestart, UtterAction,
@@ -106,6 +107,7 @@ def test_remote_action_runs(default_dispatcher_collecting, default_domain):
         'domain': default_domain.as_dict(),
         'next_action': 'my_action',
         'sender_id': 'default',
+        'version': rasa_core.__version__,
         'tracker': {
             'latest_message': {
                 'entities': [],
@@ -161,6 +163,7 @@ def test_remote_action_logs_events(default_dispatcher_collecting,
         'domain': default_domain.as_dict(),
         'next_action': 'my_action',
         'sender_id': 'default',
+        'version': rasa_core.__version__,
         'tracker': {
             'latest_message': {
                 'entities': [],


### PR DESCRIPTION
**Proposed changes**:
- part of fix for  #1568

With this PR the call to the action servers includes the rasa_core version number. This allows the server to check and compare the versions.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] updated the changelog
