### PR TITLE
Add identifier to messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Added
   (as long as the event itself is enabled in the application hosting the bot)
 - Added sanitization mechanism for SlackInput that (in its current shape and form)
   strips bot's self mentions from messages posted using the said @mentions.
-- Added a unique identifier to UserMessage and UserUttered.
+- Added a unique identifier to ``UserMessage`` and the ``UserUttered`` event.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Added
   (as long as the event itself is enabled in the application hosting the bot)
 - Added sanitization mechanism for SlackInput that (in its current shape and form)
   strips bot's self mentions from messages posted using the said @mentions.
+- Added a unique identifier to UserMessage and UserUttered.
 
 Removed
 -------

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import uuid
 from multiprocessing import Queue
 from threading import Thread
 from typing import Text, List, Dict, Any, Optional, Callable, Iterable
@@ -27,12 +28,18 @@ class UserMessage(object):
                  output_channel: Optional['OutputChannel'] = None,
                  sender_id: Text = None,
                  parse_data: Dict[Text, Any] = None,
-                 input_channel: Text = None
+                 input_channel: Text = None,
+                 message_id: Text = None
                  ) -> None:
         if text:
             self.text = text.strip()
         else:
             self.text = text
+
+        if message_id is not None:
+            self.message_id = message_id
+        else:
+            self.message_id = uuid.uuid4().hex
 
         if output_channel is not None:
             self.output_channel = output_channel

--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -37,7 +37,7 @@ class UserMessage(object):
             self.text = text
 
         if message_id is not None:
-            self.message_id = message_id
+            self.message_id = str(message_id)
         else:
             self.message_id = uuid.uuid4().hex
 

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -182,11 +182,13 @@ class UserUttered(Event):
                  entities=None,
                  parse_data=None,
                  timestamp=None,
-                 input_channel=None):
+                 input_channel=None,
+                 message_id=None):
         self.text = text
         self.intent = intent if intent else {}
         self.entities = entities if entities else []
         self.input_channel = input_channel
+        self.message_id = message_id
 
         if parse_data:
             self.parse_data = parse_data

--- a/rasa_core/processor.py
+++ b/rasa_core/processor.py
@@ -262,7 +262,8 @@ class MessageProcessor(object):
         # - instead pass its events to log
         tracker.update(UserUttered(message.text, parse_data["intent"],
                                    parse_data["entities"], parse_data,
-                                   input_channel=message.input_channel))
+                                   input_channel=message.input_channel,
+                                   message_id=message.message_id))
         # store all entities as slots
         for e in self.domain.slots_for_entities(parse_data["entities"]):
             tracker.update(e)

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -720,12 +720,14 @@ def test_int_sender_id_in_user_message():
 
     assert message.sender_id == "1234567890"
 
+
 def test_int_message_id_in_user_message():
     from rasa_core.channels import UserMessage
 
     message = UserMessage("B text", message_id=987654321)
 
     assert message.message_id == "987654321"
+
 
 def test_send_custom_messages_without_buttons():
     from rasa_core.channels.channel import OutputChannel

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -720,6 +720,12 @@ def test_int_sender_id_in_user_message():
 
     assert message.sender_id == "1234567890"
 
+def test_int_message_id_in_user_message():
+    from rasa_core.channels import UserMessage
+
+    message = UserMessage("B text", message_id=987654321)
+
+    assert message.message_id == "987654321"
 
 def test_send_custom_messages_without_buttons():
     from rasa_core.channels.channel import OutputChannel

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -24,7 +24,9 @@ def test_message_id_logging(default_processor):
     tracker = DialogueStateTracker('1', [])
     default_processor._handle_message_with_tracker(message, tracker)
     logged_event = tracker.events[-1]
+
     assert logged_event.message_id == message.message_id
+    assert logged_event.message_id is not None
 
 
 def test_parsing(default_processor):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -16,6 +16,13 @@ def test_message_processor(default_processor):
     assert {'recipient_id': 'default',
             'text': 'hey there Core!'} == out.latest_output()
 
+def test_message_id_logging(default_processor):
+    from rasa_core.trackers import DialogueStateTracker
+    message = UserMessage("If Meg was an egg would she still have a leg?")
+    tracker = DialogueStateTracker('1',[])
+    default_processor._handle_message_with_tracker(message, tracker)
+    logged_event = tracker.events[-1]
+    assert logged_event.message_id == message.message_id
 
 def test_parsing(default_processor):
     message = Message('/greet{"name": "boy"}')

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -19,6 +19,7 @@ def test_message_processor(default_processor):
 
 def test_message_id_logging(default_processor):
     from rasa_core.trackers import DialogueStateTracker
+
     message = UserMessage("If Meg was an egg would she still have a leg?")
     tracker = DialogueStateTracker('1', [])
     default_processor._handle_message_with_tracker(message, tracker)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -16,13 +16,15 @@ def test_message_processor(default_processor):
     assert {'recipient_id': 'default',
             'text': 'hey there Core!'} == out.latest_output()
 
+
 def test_message_id_logging(default_processor):
     from rasa_core.trackers import DialogueStateTracker
     message = UserMessage("If Meg was an egg would she still have a leg?")
-    tracker = DialogueStateTracker('1',[])
+    tracker = DialogueStateTracker('1', [])
     default_processor._handle_message_with_tracker(message, tracker)
     logged_event = tracker.events[-1]
     assert logged_event.message_id == message.message_id
+
 
 def test_parsing(default_processor):
     message = Message('/greet{"name": "boy"}')


### PR DESCRIPTION
**Proposed changes**:
- closes  #1228 

The UserMessage class can be intialized with a message_id, if this argument is not given an ID is generated.
The UserUttered event has a corresponding attribute which is assigned the message_id of a UserMessage by the tracker.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
