### PR TITLE
Reload model with domain

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,6 @@ Changed
 - updated docs for interactive learning to inform users of the
   ``--core`` flag
 - Change memoization policies confidence score to 1.1 to override ML policies
-- reload domain when using `/model` endpoint to upload new model
 
 Fixed
 -----
@@ -55,7 +54,7 @@ Fixed
 - re-added missing ``python-engineio`` dependency
 - fixed not working examples in ``examples/``
 - strip newlins from messages so you don't have something like "\n/restart\n"
-
+- properly reload domain when using `/model` endpoint to upload new model
 
 [0.12.3] - 2018-12-03
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Changed
 - updated docs for interactive learning to inform users of the
   ``--core`` flag
 - Change memoization policies confidence score to 1.1 to override ML policies
+- reload domain when using `/model` endpoint to upload new model
 
 Fixed
 -----

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -14,6 +14,7 @@ from rasa_core import utils, constants
 from rasa_core.channels import CollectingOutputChannel, UserMessage
 from rasa_core.evaluate import run_story_evaluation
 from rasa_core.events import Event
+from rasa_core.domain import Domain
 from rasa_core.policies import PolicyEnsemble
 from rasa_core.trackers import DialogueStateTracker, EventVerbosity
 from rasa_core.version import __version__
@@ -478,8 +479,11 @@ def create_app(agent,
         logger.debug("Unzipped model to {}".format(
             os.path.abspath(model_directory)))
 
+        domain_path = os.path.join(os.path.abspath(model_directory),
+                                   "domain.yml")
+        domain = Domain.load(domain_path)
         ensemble = PolicyEnsemble.load(model_directory)
-        agent.policy_ensemble = ensemble
+        agent.update_model(domain, ensemble, None)
         logger.debug("Finished loading new agent.")
         return '', 204
 


### PR DESCRIPTION
**Proposed changes**:

When reloading models with `/model` endpoint domain will also be reloaded (not only policy ensemble).

Related issue: #1594

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation **(doesn't apply)**
- [x] updated the changelog
