### PR TITLE
improve error message in case policy module could not be loaded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Added
 - Added sanitization mechanism for SlackInput that (in its current shape and form)
   strips bot's self mentions from messages posted using the said @mentions.
 - ``InvalidPolicyConfig`` error if policy in policy configuration could not be
-  loaded
+  loaded, or if ``policies`` key is empty or not provided
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Added
   (as long as the event itself is enabled in the application hosting the bot)
 - Added sanitization mechanism for SlackInput that (in its current shape and form)
   strips bot's self mentions from messages posted using the said @mentions.
+- ``InvalidPolicyConfig`` error if policy in policy configuration could not be
+  loaded
 
 Removed
 -------

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -217,10 +217,11 @@ class PolicyEnsemble(object):
 
     @classmethod
     def from_dict(cls, dictionary: Dict[Text, Any]) -> List[Policy]:
-        policies = dictionary.get('policies')
+        policies = dictionary.get('policies') or dictionary.get('policy')
         if policies is None:
-            raise InvalidPolicyConfig("The policy configuration file has to "
-                                      "include a key 'policies'.")
+            raise InvalidPolicyConfig("You didn't define any policies. "
+                                      "Please define them under 'policies:' in "
+                                      "your policy configuration file.")
         if len(policies) == 0:
             raise InvalidPolicyConfig("The policy configuration file has to "
                                       "include at least one policy.")

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -257,7 +257,8 @@ class PolicyEnsemble(object):
             else:
                 raise InvalidPolicyConfig("Module for policy '{}' could not be "
                                           "loaded. Please make sure the name "
-                                          "is a valid policy.".format(policy_name))
+                                          "is a valid policy."
+                                          "".format(policy_name))
 
         return parsed_policies
 

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -256,7 +256,7 @@ class PolicyEnsemble(object):
             else:
                 raise InvalidPolicyConfig("Module for policy '{}' could not be "
                                           "loaded. Please make sure the name "
-                                          "is valid.".format(policy_name))
+                                          "is a valid policy.".format(policy_name))
 
         return parsed_policies
 

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -242,9 +242,14 @@ class PolicyEnsemble(object):
                 policy['featurizer'] = featurizer_func(**featurizer_config)
 
             constr_func = utils.class_from_module_path(policy_name)
-            policy_object = constr_func(**policy)
 
-            policies.append(policy_object)
+            if constr_func:
+                policy_object = constr_func(**policy)
+                policies.append(policy_object)
+            else:
+                raise InvalidPolicyConfig("Module for policy '{}' could not be "
+                                          "loaded. Please make sure the name "
+                                          "is valid.".format(policy_name))
 
         return policies
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,7 +1,7 @@
 import pytest
 
 from rasa_core.policies import Policy
-from rasa_core.policies.ensemble import PolicyEnsemble
+from rasa_core.policies.ensemble import PolicyEnsemble, InvalidPolicyConfig
 
 
 class WorkingPolicy(Policy):
@@ -77,3 +77,16 @@ def test_policy_loading_load_returns_wrong_type(tmpdir):
 
     with pytest.raises(Exception):
         PolicyEnsemble.load(str(tmpdir))
+
+
+def test_policy_from_dict_with_valid_module():
+    test_dict = {"policies": [{"name": "MemoizationPolicy"}]}
+
+    assert PolicyEnsemble.from_dict(test_dict)
+
+
+def test_policy_from_dict_with_invalid_module():
+    test_dict = {"policies": [{"name": "ykaüoppodas"}]}
+
+    with pytest.raises(InvalidPolicyConfig):
+        assert PolicyEnsemble.from_dict(test_dict)

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -79,16 +79,18 @@ def test_policy_loading_load_returns_wrong_type(tmpdir):
         PolicyEnsemble.load(str(tmpdir))
 
 
-def test_policy_from_dict_with_valid_module():
-    test_dict = {"policies": [{"name": "MemoizationPolicy"}]}
-
-    assert PolicyEnsemble.from_dict(test_dict)
+@pytest.mark.parametrize("valid_config", [
+    {"policy": [{"name": "MemoizationPolicy"}]},
+    {"policies": [{"name": "MemoizationPolicy"}]}])
+def test_valid_policy_configurations(valid_config):
+    assert PolicyEnsemble.from_dict(valid_config)
 
 
 @pytest.mark.parametrize("invalid_config", [
-    {"policy": [{"name": "MemoizationPolicy"}]},
+    {"police": [{"name": "MemoizationPolicy"}]},
     {"policies": []},
-    {"policies": [{"name": "ykaüoppodas"}]}])
+    {"policies": [{"name": "ykaüoppodas"}]},
+    {"policy": [{"name": "ykaüoppodas"}]}])
 def test_invalid_policy_configurations(invalid_config):
     with pytest.raises(InvalidPolicyConfig):
         PolicyEnsemble.from_dict(invalid_config)


### PR DESCRIPTION
**Proposed changes**:
- fixes https://github.com/RasaHQ/rasa_core/issues/1576
- fixes https://github.com/RasaHQ/rasa_core/issues/1575
- raise `InvalidPolicyConfig` error in case the policy in the module could not be loaded, the `policies` key is empty or not there

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- ~[ ] updated the documentation~
- [x] updated the changelog
