### PR TITLE
handle passing in None for a channels route

### DIFF
--- a/rasa_core/channels/channel.py
+++ b/rasa_core/channels/channel.py
@@ -59,10 +59,14 @@ class UserMessage(object):
 def register(input_channels: List['InputChannel'],
              app: Flask,
              on_new_message: Callable[[UserMessage], None],
-             route: Text
+             route: Optional[Text]
              ) -> None:
     for channel in input_channels:
-        p = urljoin(route, channel.url_prefix())
+        if route:
+            p = urljoin(route, channel.url_prefix())
+        else:
+            p = None
+
         app.register_blueprint(channel.blueprint(on_new_message), url_prefix=p)
 
 
@@ -290,6 +294,7 @@ class QueueOutputChannel(CollectingOutputChannel):
         return "queue"
 
     def __init__(self, message_queue: Queue = None) -> None:
+        super(QueueOutputChannel).__init__()
         self.messages = Queue() if not message_queue else message_queue
 
     def latest_output(self):

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -756,14 +756,12 @@ def test_newsline_strip():
 def test_register_channel_without_route():
     """Check we properly connect the input channel blueprint if route is None"""
     from rasa_core.channels import RestInput
+    from flask import Flask
+    import rasa_core
 
     # load your trained agent
     agent = Agent.load(MODEL_PATH, interpreter=RegexInterpreter())
-
     input_channel = RestInput()
-
-    from flask import Flask
-    import rasa_core
 
     app = Flask(__name__)
     rasa_core.channels.channel.register([input_channel],

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -3,6 +3,8 @@ import json
 from httpretty import httpretty
 
 from rasa_core import utils
+from rasa_core.agent import Agent
+from rasa_core.interpreter import RegexInterpreter
 from rasa_core.utils import EndpointConfig
 from tests import utilities
 from tests.conftest import MOODBOT_MODEL_PATH
@@ -716,6 +718,7 @@ def test_channel_inheritance():
 def test_int_sender_id_in_user_message():
     from rasa_core.channels import UserMessage
 
+    # noinspection PyTypeChecker
     message = UserMessage("A text", sender_id=1234567890)
 
     assert message.sender_id == "1234567890"
@@ -724,6 +727,7 @@ def test_int_sender_id_in_user_message():
 def test_int_message_id_in_user_message():
     from rasa_core.channels import UserMessage
 
+    # noinspection PyTypeChecker
     message = UserMessage("B text", message_id=987654321)
 
     assert message.message_id == "987654321"
@@ -747,3 +751,26 @@ def test_newsline_strip():
     message = UserMessage("\n/restart\n")
 
     assert message.text == "/restart"
+
+
+def test_register_channel_without_route():
+    """Check we properly connect the input channel blueprint if route is None"""
+    from rasa_core.channels import RestInput
+
+    # load your trained agent
+    agent = Agent.load(MODEL_PATH, interpreter=RegexInterpreter())
+
+    input_channel = RestInput()
+
+    from flask import Flask
+    import rasa_core
+
+    app = Flask(__name__)
+    rasa_core.channels.channel.register([input_channel],
+                                        app,
+                                        agent.handle_message,
+                                        route=None)
+
+    routes_list = utils.list_routes(app)
+    assert routes_list.get("/webhook").startswith(
+            "custom_webhook_RestInput.receive")

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -771,4 +771,4 @@ def test_register_channel_without_route():
 
     routes_list = utils.list_routes(app)
     assert routes_list.get("/webhook").startswith(
-            "custom_webhook_RestInput.receive")
+        "custom_webhook_RestInput.receive")


### PR DESCRIPTION
**Proposed changes**:
- properly handle if `route` is set to `None` for a blueprint of an input channel when registering

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the changelog
