### PR TITLE
Fix of __init__py path in doc and two typos

### DIFF
--- a/docs/docker_walkthrough.rst
+++ b/docs/docker_walkthrough.rst
@@ -533,8 +533,8 @@ Start with creating the custom actions in a directory ``actions``:
 
   mkdir actions
   # Rasa Core SDK expects a python module.
-  # Therefore, make sure that you have this file in the direcotry.
-  touch __init__.py
+  # Therefore, make sure that you have this file in the directory.
+  touch actions/__init__.py
   touch actions/actions.py
 
 Then build a custom action using the Rasa Core SDK, e.g.:
@@ -600,7 +600,7 @@ dependencies, e.g.:
 
 .. code-block:: docker
 
-    # Extend the offical Rasa Core SDK image
+    # Extend the official Rasa Core SDK image
     FROM rasa/rasa_core_sdk:latest
 
     # Add a custom system library (e.g. git)


### PR DESCRIPTION
**Proposed changes**:
- Path to __ init__.py altered so now Python can import it properly
- Two typos are corrected