### PR TITLE
update binder requirements

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,3 +1,4 @@
 -r ../requirements.txt
 
 sklearn-crfsuite==0.3.6
+service_identity==18.1.0


### PR DESCRIPTION
**Proposed changes**:
Fixes: https://github.com/RasaHQ/rasa_core/issues/1543
- Quickstart throws a warning that service_identity is missing. Updated binder requirements to include it.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
