### PR TITLE
Test starter pack tests on new version builds only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_success:
 - coveralls
 jobs:
   include:
-  - stage: test
+  - stage: integration
     name: "Test API specification"
     language: python
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ after_success:
 - coveralls
 jobs:
   include:
-  - stage: integration
+  - stage: test
     name: "Test API specification"
     language: python
     install:
@@ -30,13 +30,14 @@ jobs:
     - swagger-cli validate docs/_static/spec/server.yml
     after_success:
     - coveralls
-  - stage: integration
+  - stage: test
+    if: branch = "*.x" # only new Core version builds test the starter pack
     name: "Test stack starter pack"
     script:
     - git clone https://github.com/RasaHQ/starter-pack-rasa-stack.git
     - cd starter-pack-rasa-stack
     - python -m pytest tests/test_core.py
-  - stage: integration
+  - stage: test
     name: "Test Docs"
     install:
     - pip install -r docs-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
     after_success:
     - coveralls
   - stage: test
-    if: branch = "*.x" # only new Core version builds test the starter pack
+    if: branch =~ /(\d\.\d{1,2}\.x)/ or branch = "master" # only master and new Core builds test the starter pack
     name: "Test stack starter pack"
     script:
     - git clone https://github.com/RasaHQ/starter-pack-rasa-stack.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ jobs:
     - git commit --allow-empty -m "trigger core docs update"
     - git push origin master
   - stage: deploy
+    name: "PyPI test"
     python: 3.6
     install: skip
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
     - git clone https://github.com/RasaHQ/starter-pack-rasa-stack.git
     - cd starter-pack-rasa-stack
     - python -m pytest tests/test_core.py
-  - stage: test
+  - stage: integration
     name: "Test Docs"
     install:
     - pip install -r docs-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
     after_success:
     - coveralls
   - stage: test
-    if: branch =~ /(\d\.\d{1,2}\.x)/ or branch = "master" # only master and new Core builds test the starter pack
+    if: branch =~ /(\d+\.\d+\.x)/ or branch = "master" # only master and new Core builds test the starter pack
     name: "Test stack starter pack"
     script:
     - git clone https://github.com/RasaHQ/starter-pack-rasa-stack.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ jobs:
     - git commit --allow-empty -m "trigger core docs update"
     - git push origin master
   - stage: deploy
-    name: "PyPI test"
+    name: "Deploy to PyPI"
     python: 3.6
     install: skip
     script: skip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,6 @@ Changed
 -------
 - starter packs are now tested in parallel with the unittests,
   and only on branches ending in ``.x`` (i.e. new version releases)
-- API specification is tested in parallel with unittests by Travis
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Added
 
 Changed
 -------
+- starter packs are now tested in parallel with the unittests,
+  and only on branches ending in ``.x`` (i.e. new version releases)
+- API specification is tested in parallel with unittests by Travis
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 Changed
 -------
 - starter packs are now tested in parallel with the unittests,
-  and only on branches ending in ``.x`` (i.e. new version releases)
+  and only on master and branches ending in ``.x`` (i.e. new version releases)
 
 Removed
 -------


### PR DESCRIPTION
To fix #1662 

**Proposed changes**:
- Starter pack tests moved into first Travis test stage
- Tests only run on new version branches and `master`

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
