### PR TITLE
Fill form slots from form trigger message intent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Added
 - ``tf.ConfigProto`` configuration can now be specified
   for tensorflow based pipelines
 - open api spec for the Rasa Core SDK action server
+- ``Tracker.active_form`` now includes ``trigger_message`` attribute to allow
+  access to message triggering the form
 
 Changed
 -------

--- a/docs/slotfilling.rst
+++ b/docs/slotfilling.rst
@@ -138,7 +138,11 @@ The predefined functions work as follows:
 - ``self.from_intent(intent=intent_name, value=value)``
   will fill slot ``slot_name`` with ``value`` if user intent is ``intent_name``.
   To make a boolean slot, take a look at the definition of ``outdoor_seating``
-  above.
+  above. Note: Slot will not be filled with user intent of message triggering
+  the form action. Use ``self.from_trigger_intent`` below.
+- ``self.from_trigger_intent(intent=intent_name, value=value)``
+  will fill slot ``slot_name`` with ``value`` if form was triggered with user
+  intent ``intent_name``.
 - ``self.from_text(intent=intent_name)`` will use the next
   user utterance to fill the text slot ``slot_name`` regardless of user intent
   if ``intent_name`` is ``None`` else only if user intent is ``intent_name``.

--- a/rasa_core/events/__init__.py
+++ b/rasa_core/events/__init__.py
@@ -835,8 +835,9 @@ class Form(Event):
     """
     type_name = "form"
 
-    def __init__(self, name, timestamp=None):
+    def __init__(self, name, trigger_message=None, timestamp=None):
         self.name = name
+        self.trigger_message = trigger_message if trigger_message else {}
         super(Form, self).__init__(timestamp)
 
     def __str__(self):
@@ -858,16 +859,18 @@ class Form(Event):
     @classmethod
     def _from_story_string(cls, parameters):
         """Called to convert a parsed story line into an event."""
-        return [Form(parameters.get("name"),
-                     parameters.get("timestamp"))]
+        return [Form(
+            name=parameters.get("name"),
+            trigger_message=parameters.get("trigger_message"),
+            timestamp=parameters.get("timestamp"))]
 
     def as_dict(self):
         d = super(Form, self).as_dict()
-        d.update({"name": self.name})
+        d.update({"name": self.name, "trigger_message": self.trigger_message})
         return d
 
     def apply_to(self, tracker: 'DialogueStateTracker') -> None:
-        tracker.change_form_to(self.name)
+        tracker.change_form_to(self.name, self.trigger_message)
 
 
 class FormValidation(Event):

--- a/rasa_core/trackers.py
+++ b/rasa_core/trackers.py
@@ -145,12 +145,13 @@ class DialogueStateTracker(object):
         generated_states = domain.states_for_tracker_history(self)
         return deque((frozenset(s.items()) for s in generated_states))
 
-    def change_form_to(self, form_name: Text) -> None:
+    def change_form_to(self, form_name: Text, trigger_message: Text) -> None:
         """Activate or deactivate a form"""
         if form_name is not None:
             self.active_form = {'name': form_name,
                                 'validate': True,
-                                'rejected': False}
+                                'rejected': False,
+                                'trigger_message': trigger_message}
         else:
             self.active_form = {}
 


### PR DESCRIPTION
@Ghostvv and myself discussed a way to allow form slots to be filled from the intent of the trigger message [here](https://forum.rasa.com/t/fill-form-slot-with-intent-of-initial-message/4744)

**Proposed changes**:
- Form event is now initialized with its trigger message
- Added a `trigger_message` attribute to `tracker.active_form`

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
