### PR TITLE
changed slack_channel name specification

### DIFF
--- a/docs/connectors.rst
+++ b/docs/connectors.rst
@@ -234,7 +234,7 @@ you need to supply a ``credentials.yml`` with the following content:
 
    slack:
      slack_token: "xoxb-286425452756-safjasdf7sl38KLls"
-     slack_channel: "@my_channel"
+     slack_channel: "#my_channel"
 
 
 The endpoint for receiving slack messages is


### PR DESCRIPTION
**Proposed changes**:
- Changed slack_channel name specification. When channel name is specified as '@channel_name' bot messages don't get posted on a channel. According to [Slack Web API](https://api.slack.com/methods/chat.postMessage#channels) the channel should be specified either as a channel id or as a channel name in a form of '#channel_name'.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
