### PR TITLE
WIP: sort the scores array in server.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 -------
 - starter packs are now tested in parallel with the unittests,
   and only on master and branches ending in ``.x`` (i.e. new version releases)
+- ``scores`` array returned by the ``/conversations/{sender_id}/predict``
+  endpoint is now sorted according to the actions' scores.
 
 Removed
 -------

--- a/docs/_static/spec/server.yml
+++ b/docs/_static/spec/server.yml
@@ -343,10 +343,11 @@ paths:
       - Tracker
       summary: Predict the next action
       description: >-
-        Runs the conversations tracker through the models
-        policies to predict the next action. The action is
-        not executed, just returned. The state of the tracker
-        is not modified.
+        Runs the conversations tracker through the model's
+        policies to predict the scores of all actions present
+        in the model's domain. Actions are returned in the
+        'scores' array, sorted on their 'score' values.
+        The state of the tracker is not modified.
       operationId: predictAction
       parameters:
       - $ref: '#/components/parameters/senderId'

--- a/rasa_core/server.py
+++ b/rasa_core/server.py
@@ -407,6 +407,9 @@ def create_app(agent,
         try:
             # Fetches the appropriate bot response in a json format
             responses = agent.predict_next(sender_id)
+            responses['scores'] = sorted(responses['scores'],
+                                         key = lambda k: (-k['score'],
+                                                          k['action']))
             return jsonify(responses)
 
         except Exception as e:

--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -601,13 +601,10 @@ def _request_action_from_user(
 
     _print_history(sender_id, endpoint)
 
-    sorted_actions = sorted(predictions,
-                            key=lambda k: (-k['score'], k['action']))
-
     choices = [{"name": "{:03.2f} {:40}".format(a.get("score"),
                                                 a.get("action")),
                 "value": a.get("action")}
-               for a in sorted_actions]
+               for a in predictions]
 
     choices = [{"name": "<create new action>", "value": OTHER_ACTION}] + choices
     question = questionary.select("What is the next action of the bot?",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -207,6 +207,20 @@ def test_predict(http_app, app):
     assert response.status_code == 200
 
 
+def test_sorted_predict(http_app, app):
+    client = RasaCoreClient(EndpointConfig(http_app))
+    cid = str(uuid.uuid1())
+    for event in test_events[:3]:
+        client.append_event_to_tracker(cid, event)
+    response = app.post("http://dummy/conversations/{}/predict".format(cid))
+    content = response.get_json()
+    scores = content["scores"]
+    sorted_scores = sorted(scores,
+                           key = lambda k: (-k['score'],
+                                            k['action']))
+    assert scores == sorted_scores
+
+
 def test_evaluate(app):
     with io.open(DEFAULT_STORIES_FILE, 'r') as f:
         stories = f.read()


### PR DESCRIPTION
#1707 
**Proposed changes**:
- Sorting the actions in `score ` array returned from HTTP API endpoint :- `/conversations/{sender_id}/predict` 
- Remove the sorting logic from `training.interactive._request_action_from_user() `

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog

@tmbo I have added-deleted the sort from the aforementioned places, what do you think? Also, I am confused about writing new tests for these changes, the tests already in test_server.py should suffice right? or am I missing something?