### PR TITLE
Adding auth_source param in Mongo DB Tracker Store documentation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 
+[0.13.3] - 2019-03-04
+^^^^^^^^^^^^^^^^^^^^^
+
+Added
+-------
+- Tracker Store Mongo DB's documentation now has ``auth_source`` parameter, which is used for passing database name associated with the user's credentials. 
+
 [0.13.2] - 2019-02-06
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/tracker_stores.rst
+++ b/docs/tracker_stores.rst
@@ -78,6 +78,7 @@ MongoTrackerStore
                 db: <name of the db within your mongo instance, e.g. rasa>
                 username: <username used for authentication>
                 password: <password used for authentication>
+                auth_source: <database name associated with the user’s credentials>
         
         You can also add more advanced configurations (like enabling ssl) by appending
         a parameter to the url field, e.g. mongodb://localhost:27017/?ssl=true
@@ -95,6 +96,7 @@ MongoTrackerStore
     - ``password`` (default: ``None``): The password which is used for authentication
     - ``collection`` (default: ``conversations``): The collection name which is
       used to store the conversations
+    - ``auth_source`` (default: ``the database specified in the connection string``): database name associated with the user’s credentials.
 
 Custom Tracker Store
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/tracker_stores.rst
+++ b/docs/tracker_stores.rst
@@ -96,7 +96,7 @@ MongoTrackerStore
     - ``password`` (default: ``None``): The password which is used for authentication
     - ``collection`` (default: ``conversations``): The collection name which is
       used to store the conversations
-    - ``auth_source`` (default: ``the database specified in the connection string``): database name associated with the user’s credentials.
+    - ``auth_source`` (default: ``admin``): database name associated with the user’s credentials.
 
 Custom Tracker Store
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
If anyone has different database name associated with the user’s credentials then they have to specify this parameter.

**Proposed changes**:
- auth_source param was missing in the documentation for Tracker store for Mongo DB.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
