### PR TITLE
update interactive.py

### DIFF
--- a/rasa_core/training/interactive.py
+++ b/rasa_core/training/interactive.py
@@ -739,13 +739,17 @@ def _write_nlu_to_file(
         previous_examples = TrainingData()
 
     nlu_data = previous_examples.merge(TrainingData(msgs))
-
+    
+    if _guess_format(export_nlu_path) in {"md", "unk"}:
+            fformat = "md"
+        else:
+            fformat = "json"
+            
     with io.open(export_nlu_path, 'w', encoding="utf-8") as f:
-        if _guess_format(export_nlu_path) in {"md", "unk"}:
+        if fformat == "md":
             f.write(nlu_data.as_markdown())
         else:
             f.write(nlu_data.as_json())
-
 
 def _entities_from_messages(messages):
     """Return all entities that occur in atleast one of the messages."""


### PR DESCRIPTION
When trying to detect format of the training data file in the `_write_nlu_to_file` function, there is a conflict between the opening of the file in writing mode and the call to the `_guess_format` fonction from rasa_nlu/rasa_nlu/training_data/loading.py.

Indeed, after the opening, the file is everytime detected as markdown by the `_guess_format` func because the `js = json.loads(content)` loads an empty file resulting in wrong detection (if the file is a json). 

Quick fix to avoid that.

**Proposed changes**:
- opening the file in writing mode only after detecting the format

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
