### PR TITLE
0.13.x update docs

### DIFF
--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -72,7 +72,7 @@ Here's an example of what an end-to-end story file may look like:
   ...
 
 
-If you've saved these stories under ``e2e_storied.md``,
+If you've saved these stories under ``e2e_stories.md``,
 the full end-to-end evaluation command is this:
 
 .. code-block:: bash

--- a/docs/fallbacks.rst
+++ b/docs/fallbacks.rst
@@ -14,19 +14,20 @@ be executed if the intent recognition has a confidence below ``nlu_threshold``
 or if none of the dialogue policies predict an action with
 confidence higher than ``core_threshold``.
 
-The ``rasa_core.train`` scripts provides parameters to adjust these
-thresholds:
+The thresholds and fallback action can be adjusted in the policy configuration
+file as parameters of the ``FallbackPolicy``:
 
-+-----------------------+------------------------------------------------------+
-| ``--nlu_threshold``   | min confidence needed                                |
-|                       | to accept an NLU prediction                          |
-+-----------------------+------------------------------------------------------+
-| ``--core_threshold``  | min confidence needed                                |
-|                       | to accept an action prediction from Rasa Core        |
-+-----------------------+------------------------------------------------------+
-| ``--fallback_action`` | name of the action to be called if the confidence    |
-|                       | of intent / action prediction is below the threshold |
-+-----------------------+------------------------------------------------------+
+.. code-block:: yaml
+
+  policies:
+    - name: "FallbackPolicy"
+      # min confidence needed to accept an NLU prediction
+      nlu_threshold: 0.3
+      # min confidence needed to accept an action prediction from Rasa Core
+      core_threshold: 0.3
+      # name of the action to be called if the confidence of intent / action
+      # is below the threshold
+      fallback_action_name: 'action_default_fallback'
 
 If you want to run this from python, use:
 

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -19,7 +19,7 @@ You can run training from the command line like in the :ref:`quickstart`:
 .. code-block:: bash
 
    python -m rasa_core.train -d domain.yml -s data/stories.md \
-     -o models/dialogue -c config.yml
+     -o models/current/dialogue -c config.yml
 
 Or by creating an agent and running the train method yourself:
 

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -19,7 +19,7 @@ You can run training from the command line like in the :ref:`quickstart`:
 .. code-block:: bash
 
    python -m rasa_core.train -d domain.yml -s data/stories.md \
-     -o models/current/dialogue -c config.yml
+     -o models/dialogue -c config.yml
 
 Or by creating an agent and running the train method yourself:
 
@@ -182,11 +182,6 @@ You can pass a list of policies when you create an agent:
                   policies=[MemoizationPolicy(), KerasPolicy()])
 
 
-.. note::
-
-    By default, Rasa Core uses the ``KerasPolicy`` in combination with
-    the ``MemoizationPolicy``.
-
 Memoization Policy
 ^^^^^^^^^^^^^^^^^^
 
@@ -272,19 +267,20 @@ It is recommended to use
 
 **Configuration**:
 
-    Configuration parameters can be passed to ``agent.train(...)`` method.
+    Configuration parameters can be passed as parameters to the
+    ``EmbeddingPolicy`` within the policy configuration file.
 
     .. note::
 
-        Pass an appropriate ``epochs`` number to ``agent.train(...)``
-        method, otherwise the policy will be trained only for ``1`` epoch.
-        Since this is embedding based policy, it requires a large
+        Pass an appropriate number of ``epochs`` to the ``EmbeddingPolicy``,
+        otherwise the policy will be trained only for ``1``
+        epoch. Since this is an embedding based policy, it requires a large
         number of epochs, which depends on the complexity of the
         training data and whether attention is used or not.
 
     The main feature of this policy is an **attention** mechanism over
     previous user input and system actions.
-    **Attention is turned on by default**, in order to turn it off,
+    **Attention is turned on by default**; in order to turn it off,
     configure the following parameters:
 
         - ``attn_before_rnn`` if ``true`` the algorithm will use
@@ -325,7 +321,7 @@ It is recommended to use
               forward/backward pass, the higher the batch size, the more
               memory space you'll need;
             - ``epochs`` sets the number of times the algorithm will see
-              training data, where ``one epoch`` = one forward pass and
+              training data, where one ``epoch`` equals one forward pass and
               one backward pass of all the training examples;
             - ``random_seed`` if set to any int will get reproducible
               training results for the same inputs;
@@ -385,7 +381,7 @@ It is recommended to use
         ``batch_size`` is required, pass an ``int``, e.g.
         ``"batch_size": 8``.
 
-    These parameters can be passed to ``Agent.train(...)`` method.
+    These parameters can be specified in the policy configuration file.
     The default values are defined in ``EmbeddingPolicy.defaults``:
 
    .. literalinclude:: ../rasa_core/policies/embedding_policy.py


### PR DESCRIPTION
**Proposed changes**:
- Update docs to remove out-of-date information about where to pass arguments to certain policies (i.e. command line or `agent.train()` instead of the policy configuration file)
- Fix incorrect output file in training command
- Part 1 of #1678

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [x] updated the documentation
- [ ] updated the changelog
