### PR TITLE
Logging fallback policy

### DIFF
--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -354,14 +354,16 @@ class SimplePolicyEnsemble(PolicyEnsemble):
                 best_policy_index = i
 
         if logging.getLogger().level == logging.DEBUG:
+            # Logger should inform you when fallback was invoked because of low core_threshold,
+            # so people know it was the action prediction and not the intent classification that
+            # messed up.
             fallback_idx_policy = [(i, p) for i, p in enumerate(self.policies)
                                     if isinstance(p, FallbackPolicy)]
-
             if fallback_idx_policy:
                 fallback_idx, fallback_policy = fallback_idx_policy[0]
                 if fallback_idx == best_policy_index and fallback_policy.core_threshold_set:
-                     logger.debug("fallback policy was invoked because of core_threshold")
-
+                    logger.debug("Fallback policy was invoked because of core_threshold ({})".format(
+                        fallback_policy.core_threshold))
 
         if (result.index(max_confidence) ==
                 domain.index_for_action(ACTION_LISTEN_NAME) and

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -362,7 +362,7 @@ class SimplePolicyEnsemble(PolicyEnsemble):
             if fallback_idx_policy:
                 fallback_idx, fallback_policy = fallback_idx_policy[0]
                 if fallback_idx == best_policy_index and \
-                        fallback_policy.core_threshold_set:
+                        fallback_policy.should_core_fallback:
                     logger.debug("Fallback policy was invoked because of "
                                  "core_threshold ({})"
                                  .format(fallback_policy.core_threshold))

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -335,6 +335,7 @@ class SimplePolicyEnsemble(PolicyEnsemble):
         max_confidence = -1
         best_policy_name = None
         best_policy_priority = -1
+        best_policy_index = -1
 
         for i, p in enumerate(self.policies):
             probabilities = p.predict_action_probabilities(tracker, domain)
@@ -350,6 +351,17 @@ class SimplePolicyEnsemble(PolicyEnsemble):
                 result = probabilities
                 best_policy_name = 'policy_{}_{}'.format(i, type(p).__name__)
                 best_policy_priority = p.priority
+                best_policy_index = i
+
+        if logging.getLogger().level == logging.DEBUG:
+            fallback_idx_policy = [(i, p) for i, p in enumerate(self.policies)
+                                    if isinstance(p, FallbackPolicy)]
+
+            if fallback_idx_policy:
+                fallback_idx, fallback_policy = fallback_idx_policy[0]
+                if fallback_idx == best_policy_index and fallback_policy.core_threshold_set:
+                     logger.debug("fallback policy was invoked because of core_threshold")
+
 
         if (result.index(max_confidence) ==
                 domain.index_for_action(ACTION_LISTEN_NAME) and

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -354,9 +354,8 @@ class SimplePolicyEnsemble(PolicyEnsemble):
                 best_policy_index = i
 
         if logging.getLogger().level == logging.DEBUG:
-            # Logger should inform you when fallback was invoked because of low core_threshold,
-            # so people know it was the action prediction and not the intent classification that
-            # messed up.
+            # When fallback was invoked because of low core_threshold, log the information so that people know it was
+            # the action prediction and not the intent classification that messed up.
             fallback_idx_policy = [(i, p) for i, p in enumerate(self.policies)
                                     if isinstance(p, FallbackPolicy)]
             if fallback_idx_policy:

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -335,7 +335,6 @@ class SimplePolicyEnsemble(PolicyEnsemble):
         max_confidence = -1
         best_policy_name = None
         best_policy_priority = -1
-        best_policy_index = -1
 
         for i, p in enumerate(self.policies):
             probabilities = p.predict_action_probabilities(tracker, domain)
@@ -351,21 +350,6 @@ class SimplePolicyEnsemble(PolicyEnsemble):
                 result = probabilities
                 best_policy_name = 'policy_{}_{}'.format(i, type(p).__name__)
                 best_policy_priority = p.priority
-                best_policy_index = i
-
-        if logger.level == logging.DEBUG:
-            # When fallback was invoked because of low core_threshold,
-            # log the information so that people know it was the action
-            # prediction and not the intent classification that messed up.
-            fallback_idx_policy = [(i, p) for i, p in enumerate(self.policies)
-                                   if isinstance(p, FallbackPolicy)]
-            if fallback_idx_policy:
-                fallback_idx, fallback_policy = fallback_idx_policy[0]
-                if fallback_idx == best_policy_index and \
-                        fallback_policy.should_core_fallback:
-                    logger.debug("Fallback policy was invoked because of "
-                                 "core_threshold ({})"
-                                 .format(fallback_policy.core_threshold))
 
         if (result.index(max_confidence) ==
                 domain.index_for_action(ACTION_LISTEN_NAME) and

--- a/rasa_core/policies/ensemble.py
+++ b/rasa_core/policies/ensemble.py
@@ -353,16 +353,19 @@ class SimplePolicyEnsemble(PolicyEnsemble):
                 best_policy_priority = p.priority
                 best_policy_index = i
 
-        if logging.getLogger().level == logging.DEBUG:
-            # When fallback was invoked because of low core_threshold, log the information so that people know it was
-            # the action prediction and not the intent classification that messed up.
+        if logger.level == logging.DEBUG:
+            # When fallback was invoked because of low core_threshold,
+            # log the information so that people know it was the action
+            # prediction and not the intent classification that messed up.
             fallback_idx_policy = [(i, p) for i, p in enumerate(self.policies)
-                                    if isinstance(p, FallbackPolicy)]
+                                   if isinstance(p, FallbackPolicy)]
             if fallback_idx_policy:
                 fallback_idx, fallback_policy = fallback_idx_policy[0]
-                if fallback_idx == best_policy_index and fallback_policy.core_threshold_set:
-                    logger.debug("Fallback policy was invoked because of core_threshold ({})".format(
-                        fallback_policy.core_threshold))
+                if fallback_idx == best_policy_index and \
+                        fallback_policy.core_threshold_set:
+                    logger.debug("Fallback policy was invoked because of "
+                                 "core_threshold ({})"
+                                 .format(fallback_policy.core_threshold))
 
         if (result.index(max_confidence) ==
                 domain.index_for_action(ACTION_LISTEN_NAME) and

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -28,7 +28,8 @@ class FallbackPolicy(Policy):
                  priority: int = 3,
                  nlu_threshold: float = 0.3,
                  core_threshold: float = 0.3,
-                 fallback_action_name: Text = "action_default_fallback"
+                 fallback_action_name: Text = "action_default_fallback",
+                 core_threshold_set: bool = False,
                  ) -> None:
         """Create a new Fallback policy.
 
@@ -47,6 +48,7 @@ class FallbackPolicy(Policy):
         self.nlu_threshold = nlu_threshold
         self.core_threshold = core_threshold
         self.fallback_action_name = fallback_action_name
+        self.core_threshold_set = core_threshold_set
 
     def train(self,
               training_trackers: List[DialogueStateTracker],
@@ -112,6 +114,7 @@ class FallbackPolicy(Policy):
             # predict fallback action with confidence `core_threshold`
             # if this is the highest confidence in the ensemble,
             # the fallback action will be executed.
+            self.core_threshold_set = True
             result = self.fallback_scores(domain, self.core_threshold)
 
         return result

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -29,7 +29,6 @@ class FallbackPolicy(Policy):
                  nlu_threshold: float = 0.3,
                  core_threshold: float = 0.3,
                  fallback_action_name: Text = "action_default_fallback",
-                 core_threshold_set: bool = False,
                  ) -> None:
         """Create a new Fallback policy.
 
@@ -48,7 +47,7 @@ class FallbackPolicy(Policy):
         self.nlu_threshold = nlu_threshold
         self.core_threshold = core_threshold
         self.fallback_action_name = fallback_action_name
-        self.core_threshold_set = core_threshold_set
+        self.core_threshold_set = False
 
     def train(self,
               training_trackers: List[DialogueStateTracker],

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -28,7 +28,7 @@ class FallbackPolicy(Policy):
                  priority: int = 3,
                  nlu_threshold: float = 0.3,
                  core_threshold: float = 0.3,
-                 fallback_action_name: Text = "action_default_fallback",
+                 fallback_action_name: Text = "action_default_fallback"
                  ) -> None:
         """Create a new Fallback policy.
 

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -88,7 +88,7 @@ class FallbackPolicy(Policy):
         The fallback action is predicted if the NLU confidence is low
         or no other policy has a high-confidence prediction.
         """
-
+        self.core_threshold_set = False
         nlu_data = tracker.latest_message.parse_data
 
         # if NLU interpreter does not provide confidence score,

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -47,7 +47,6 @@ class FallbackPolicy(Policy):
         self.nlu_threshold = nlu_threshold
         self.core_threshold = core_threshold
         self.fallback_action_name = fallback_action_name
-        self.should_core_fallback = False
 
     def train(self,
               training_trackers: List[DialogueStateTracker],
@@ -88,7 +87,6 @@ class FallbackPolicy(Policy):
         The fallback action is predicted if the NLU confidence is low
         or no other policy has a high-confidence prediction.
         """
-        self.should_core_fallback = False
         nlu_data = tracker.latest_message.parse_data
 
         # if NLU interpreter does not provide confidence score,
@@ -113,7 +111,6 @@ class FallbackPolicy(Policy):
             # predict fallback action with confidence `core_threshold`
             # if this is the highest confidence in the ensemble,
             # the fallback action will be executed.
-            self.should_core_fallback = True
             result = self.fallback_scores(domain, self.core_threshold)
 
         return result

--- a/rasa_core/policies/fallback.py
+++ b/rasa_core/policies/fallback.py
@@ -47,7 +47,7 @@ class FallbackPolicy(Policy):
         self.nlu_threshold = nlu_threshold
         self.core_threshold = core_threshold
         self.fallback_action_name = fallback_action_name
-        self.core_threshold_set = False
+        self.should_core_fallback = False
 
     def train(self,
               training_trackers: List[DialogueStateTracker],
@@ -88,7 +88,7 @@ class FallbackPolicy(Policy):
         The fallback action is predicted if the NLU confidence is low
         or no other policy has a high-confidence prediction.
         """
-        self.core_threshold_set = False
+        self.should_core_fallback = False
         nlu_data = tracker.latest_message.parse_data
 
         # if NLU interpreter does not provide confidence score,
@@ -113,7 +113,7 @@ class FallbackPolicy(Policy):
             # predict fallback action with confidence `core_threshold`
             # if this is the highest confidence in the ensemble,
             # the fallback action will be executed.
-            self.core_threshold_set = True
+            self.should_core_fallback = True
             result = self.fallback_scores(domain, self.core_threshold)
 
         return result


### PR DESCRIPTION
**Proposed changes**:
- Always evaluate FallbackPolicy last
- If FallbackPolicy was chosen in the end and the confidence is equal to the core threshold, we know that all other action prediction confidence scores were lower than the core threshold

closes #1847 

**Status (please check what you already did)**:
- [ ] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
