### PR TITLE
fixing attachment in utter_response

### DIFF
--- a/rasa/core/dispatcher.py
+++ b/rasa/core/dispatcher.py
@@ -52,7 +52,7 @@ class Dispatcher(object):
         bot_message = BotMessage(text=message.get("text"),
                                  data={"elements": message.get("elements"),
                                        "buttons": message.get("buttons"),
-                                       "attachment": message.get("image")})
+                                       "attachment": message.get("attachment")})
 
         self.latest_bot_messages.append(bot_message)
         await self.output_channel.send_response(self.sender_id, message)


### PR DESCRIPTION
**Proposed changes**:
- Doesn't seem like this made any sense. An image associated with text was being added as the attachment.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
