### PR TITLE
Extract message intent instead of setting the node with a dict when using visualization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to `Semantic Versioning`_ starting with version 0.2.0.
 
+[Unreleased 0.13.a8]
+^^^^^^^^^^^^^^^^^^^^
+
+Fixed
+-----
+- Message parse data no longer passed to graph node label in interactive
+  learning visualization
+
 [0.13.7] - 2019-04-01
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/rasa_core/training/visualization.py
+++ b/rasa_core/training/visualization.py
@@ -421,7 +421,9 @@ def visualize_neighborhood(
                     events[idx].action_name == ACTION_LISTEN_NAME):
                 next_node_idx += 1
                 graph.add_node(next_node_idx,
-                               label=message or "  ?  ",
+                               label="  ?  " if not message else
+                                     sanitize(message.get("intent", {}))
+                                     .get("name", "  ?  "),
                                shape="rect",
                                **{"class": "intent dashed active"})
                 target = next_node_idx


### PR DESCRIPTION
Fixes https://github.com/RasaHQ/rasa_nlu/issues/2995

Under certain circumstances we were passing the message parse data to the node label during interactive learning visualization, which (since this is a dictionary) was causing fatal errors.

**Proposed changes**:
- Use message intent name instead of the parse data as the graph node label

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] updated the changelog
