### PR TITLE
update timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
   - stage: test
     name: "Test CLI"
     script:
-    - timeout 2 time rasa --help
+    - timeout 3 time rasa --help
   - stage: integration
     name: "Test Docs"
     install:


### PR DESCRIPTION
I know we updated this timeout on `rasa` (though it seems we might have gotten rid of it temporarily)? -- [This PR](https://github.com/RasaHQ/rasa_core/pull/1903) keeps failing 